### PR TITLE
Remove the ContainerAwareInterface from the ConsumerInterface

### DIFF
--- a/RabbitMq/ConsumerInterface.php
+++ b/RabbitMq/ConsumerInterface.php
@@ -2,8 +2,6 @@
 
 namespace OldSound\RabbitMqBundle\RabbitMq;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-
 interface ConsumerInterface
 {
     function execute($msg);


### PR DESCRIPTION
There is not need for it.
