### PR TITLE
Pass the whole message object to consumer

### DIFF
--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -28,7 +28,7 @@ class Consumer extends BaseConsumer
         try
         {
             //TODO pass the whole message and document the usage.
-            call_user_func($this->callback, $msg->body);
+            call_user_func($this->callback, $msg);
             $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
             $this->consumed++;
             $this->maybeStopConsumer($msg);


### PR DESCRIPTION
Instead of passing only the `$msg->body` to the consumer, pass the whole $msg object.
