### PR TITLE
Pass the whole $msg object to RPC Server

### DIFF
--- a/RabbitMq/RpcServer.php
+++ b/RabbitMq/RpcServer.php
@@ -28,7 +28,7 @@ class RpcServer extends BaseConsumer
         try
         {
             $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
-            $result = call_user_func($this->callback, $msg->body);
+            $result = call_user_func($this->callback, $msg);
             $this->sendReply(serialize($result), $msg->get('reply_to'), $msg->get('correlation_id'));
         }
         catch (\Exception $e)


### PR DESCRIPTION
Instead of passing only the `$msg->body` to the RPC Server, pass the whole $msg object.
