### PR TITLE
Change configuration to work with the latest changes in Symfony master

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -71,7 +71,6 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->arrayNode('connections')
                     ->useAttributeAsKey('key')
-                    ->addDefaultsIfNotSet()
                     ->canBeUnset()
                     ->prototype('array')
                         ->children()


### PR DESCRIPTION
Removes useless/ignored config which throws an exception as of symfony/symfony#3365
