### PR TITLE
Fix exception NOT_FOUND when initializing durable exchange in producer

### DIFF
--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -36,6 +36,7 @@ class Producer extends BaseAmqp
         $this->ch->exchange_declare(
             $this->exchangeOptions['name'],
             $this->exchangeOptions['type'],
+            $this->exchangeOptions['passive'],
             $this->exchangeOptions['durable'],
             $this->exchangeOptions['auto_delete'],
             $this->exchangeOptions['internal']);


### PR DESCRIPTION
In producer the parameters are not passed correctly upon exchange declaration. This results in initialisation errors when using a durable exchange.

Thrown exception is: NOT_FOUND - no exchange '<exchangename>' in vhost '<vhost>'
