### PR TITLE
Fix for the Producer to not declare the exchange until necessary

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -66,8 +66,6 @@ class OldSoundRabbitMqExtension extends Extension
                 $this->injectLoggedChannel($definition, $key, $producer['connection']);
             }
             $definition->addMethodCall('setExchangeOptions', array($producer['exchange_options']));
-            //TODO add configuration option that allows to not do this all the time.
-            $definition->addMethodCall('exchangeDeclare');
 
             $this->container->setDefinition(sprintf('old_sound_rabbit_mq.%s_producer', $key), $definition);
         }
@@ -177,4 +175,3 @@ class OldSoundRabbitMqExtension extends Extension
         return 'old_sound_rabbit_mq';
     }
 }
-

--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -15,6 +15,8 @@ class Producer extends BaseAmqp
         'internal' => false
     );
 
+    protected $declared = false;
+
     public function __construct(AMQPConnection $conn, AMQPChannel $ch = null, $consumerTag = null)
     {
         parent::__construct($conn, $ch, $consumerTag);
@@ -40,10 +42,15 @@ class Producer extends BaseAmqp
             $this->exchangeOptions['durable'],
             $this->exchangeOptions['auto_delete'],
             $this->exchangeOptions['internal']);
+
+        $this->declared = true;
     }
 
     public function publish($msgBody, $routingKey = '')
     {
+        if (!$this->declared) {
+            $this->exchangeDeclare();
+        }
         $msg = new AMQPMessage($msgBody, array('content_type' => 'text/plain', 'delivery_mode' => 2));
         $this->ch->basic_publish($msg, $this->exchangeOptions['name'], $routingKey);
     }


### PR DESCRIPTION
Don't declare the exchange until the first call to publish()

possibly references #34
