### PR TITLE
RPC Client now has ability to be created in prototype scope

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -114,7 +114,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
-                            ->scalarNode('scope')->defaultValue('container')
+                            ->scalarNode('scope')->defaultValue(ContainerInterface::SCOPE_CONTAINER)
                                 ->validate()
                                     ->ifTrue(function($v){return !in_array($v, array(ContainerInterface::SCOPE_CONTAINER, ContainerInterface::SCOPE_PROTOTYPE));})
                                     ->thenInvalid("'Scope must be ". ContainerInterface::SCOPE_CONTAINER . " or " .ContainerInterface::SCOPE_PROTOTYPE . ".")

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -5,6 +5,7 @@ namespace OldSound\RabbitMqBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Configuration
@@ -113,6 +114,12 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
+                            ->scalarNode('scope')->defaultValue('container')
+                                ->validate()
+                                    ->ifTrue(function($v){return !in_array($v, array(ContainerInterface::SCOPE_CONTAINER, ContainerInterface::SCOPE_PROTOTYPE));})
+                                    ->thenInvalid("'Scope must be ". ContainerInterface::SCOPE_CONTAINER . " or " .ContainerInterface::SCOPE_PROTOTYPE . ".")
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -112,6 +112,7 @@ class OldSoundRabbitMqExtension extends Extension
         foreach ($this->config['rpc_clients'] as $key => $client) {
             $definition = new Definition($this->container->getParameter('old_sound_rabbit_mq.rpc_client.class'));
 
+            $definition->setScope($client['scope']);
             $this->injectConnection($definition, $client['connection']);
             if ($this->enable_collector) {
                 $this->injectLoggedChannel($definition, $key, $client['connection']);


### PR DESCRIPTION
Hello,

when I started to integrate your Bundle to my application I realized, that I need to create more then one instance for one RPC client.

If you would like, I could demonstrate why I have to have different instances for RPC Clients.

Thank you,
Oleg
