### PR TITLE
Process connections only when they are defined

### DIFF
--- a/DependencyInjection/Compiler/LoadConnectionCompilerPass.php
+++ b/DependencyInjection/Compiler/LoadConnectionCompilerPass.php
@@ -15,6 +15,10 @@ class LoadConnectionCompilerPass extends BaseCompilerPass
     {
         parent::process($container);
 
+        if (!isset($this->config['connections'])) {
+            return;
+        }
+
         foreach ($this->config['connections'] as $key => $connection) {
             $definition = new Definition($container->getParameter('old_sound_rabbit_mq.connection.class'),
                                          array(


### PR DESCRIPTION
Connections can be empty when you just added the bundle into your AppKernel, but haven't yet configured it.
