### PR TITLE
Fix minor documentation discrepancy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Here's an example callback:
 
     //src/Acme/DemoBundle/Consumer/UploadPictureConsumer.php
 
-    namespace Sensio\HelloBundle\Consumer;
+    namespace Acme\DemoBundle\Consumer;
 
     use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
     use PhpAmqpLib\Message\AMQPMessage;


### PR DESCRIPTION
Fix a minor discrepancy whereby in the callback section, the
source file was listed as Acme/DemoBundle but the namespace was listed
Sensio/HelloBundle
