### PR TITLE
Fixed issues with command arguments and pcntl extention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ env:
   - SYMFONY_VERSION=v2.0.7
   - SYMFONY_VERSION=origin/2.0
 
-before_script: ./vendor/vendors.sh
+before_script:
+    - curl -s http://getcomposer.org/installer | php
+    - php composer.phar install --dev --prefer-source

--- a/Command/BaseConsumerCommand.php
+++ b/Command/BaseConsumerCommand.php
@@ -19,9 +19,9 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
 
     public function stopConsumer()
     {
-        if($this->consumer instanceof Consumer) {
+        if ($this->consumer instanceof Consumer) {
             $this->consumer->forceStopConsumer();
-        }else{
+        } else {
             exit();
         }
     }
@@ -39,8 +39,8 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
             ->addArgument('name', InputArgument::REQUIRED, 'Consumer Name')
             ->addOption('messages', 'm', InputOption::VALUE_OPTIONAL, 'Messages to consume', 0)
             ->addOption('route', 'r', InputOption::VALUE_OPTIONAL, 'Routing Key', '')
-            ->addOption('debug', 'd', InputOption::VALUE_OPTIONAL, 'Enable Debugging', false)
-            ->addOption('without-signals', 'w', InputOption::VALUE_OPTIONAL, 'Disable catching of system signals', false)
+            ->addOption('debug', 'd', InputOption::VALUE_NONE, 'Enable Debugging')
+            ->addOption('without-signals', 'w', InputOption::VALUE_NONE, 'Disable catching of system signals')
         ;
     }
 
@@ -57,14 +57,18 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $signals = $input->getOption('without-signals');
-        if(!$signals && extension_loaded('pcntl')){
+
+        if (defined('AMQP_WITHOUT_SIGNALS') === false) {
+            define('AMQP_WITHOUT_SIGNALS', $input->getOption('without-signals'));
+        }
+
+        if (!AMQP_WITHOUT_SIGNALS && extension_loaded('pcntl')) {
             pcntl_signal(SIGTERM, array(&$this, 'stopConsumer'));
             pcntl_signal(SIGINT, array(&$this, 'stopConsumer'));
             pcntl_signal(SIGHUP, array(&$this, 'restartConsumer'));
         }
 
-        if(defined('AMQP_DEBUG') === false) {
+        if (defined('AMQP_DEBUG') === false) {
             define('AMQP_DEBUG', (bool) $input->getOption('debug'));
         }
 

--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -55,11 +55,11 @@ abstract class BaseConsumer extends BaseAmqp
 
     protected function maybeStopConsumer()
     {
-        if(extension_loaded('pcntl')) {
+        if (extension_loaded('pcntl') && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true)) {
             pcntl_signal_dispatch();
         }
 
-        if($this->forceStop || ($this->consumed == $this->target && $this->target > 0)) {
+        if ($this->forceStop || ($this->consumed == $this->target && $this->target > 0)) {
             $this->stopConsuming();
         } else {
             return;

--- a/Tests/Command/ConsumerCommandTest.php
+++ b/Tests/Command/ConsumerCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Tests\Command;
+
+use OldSound\RabbitMqBundle\Command\ConsumerCommand;
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
+
+class ConsumerCommandTest extends \PHPUnit_Framework_TestCase
+{
+    private $application;
+    private $definition;
+    private $helperSet;
+    private $command;
+
+    protected function setUp()
+    {
+        $this->application = $this->getMockBuilder('Symfony\\Bundle\\FrameworkBundle\\Console\\Application')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->definition = $this->getMockBuilder('Symfony\\Component\\Console\\Input\\InputDefinition')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->helperSet = $this->getMock('Symfony\\Component\\Console\\Helper\\HelperSet');
+
+        $this->application->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue($this->definition));
+        $this->definition->expects($this->any())
+            ->method('getArguments')
+            ->will($this->returnValue(array()));
+        $this->definition->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue(array(
+                new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
+                new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
+                new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
+            )));
+        $this->application->expects($this->once())
+            ->method('getHelperSet')
+            ->will($this->returnValue($this->helperSet));
+
+        $this->command = new ConsumerCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    /**
+     * testInputsDefinitionCommand
+     */
+    public function testInputsDefinitionCommand()
+    {
+        // check argument
+        $this->assertTrue($this->command->getDefinition()->hasArgument('name'));
+        $this->assertTrue($this->command->getDefinition()->getArgument('name')->isRequired()); // Name is required to find the service
+
+        //check options
+        $this->assertTrue($this->command->getDefinition()->hasOption('messages'));
+        $this->assertTrue($this->command->getDefinition()->getOption('messages')->isValueOptional()); // It should accept value
+
+        $this->assertTrue($this->command->getDefinition()->hasOption('route'));
+        $this->assertTrue($this->command->getDefinition()->getOption('route')->isValueOptional()); // It should accept value
+
+        $this->assertTrue($this->command->getDefinition()->hasOption('without-signals'));
+        $this->assertFalse($this->command->getDefinition()->getOption('without-signals')->acceptValue()); // It shouldn't accept value because it is a true/false input
+
+        $this->assertTrue($this->command->getDefinition()->hasOption('debug'));
+        $this->assertFalse($this->command->getDefinition()->getOption('debug')->acceptValue()); // It shouldn't accept value because it is a true/false input
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         "symfony/yaml": ">=2.0",
         "videlalvaro/php-amqplib"  : "dev-master"
     },
+    "require-dev": {
+        "symfony/console": ">=2.1.0,<2.3-dev"
+    },
     "autoload": {
         "psr-0": {
             "OldSound\\RabbitMqBundle\\": ""

--- a/vendor/vendors.sh
+++ b/vendor/vendors.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-curl -s http://getcomposer.org/installer | php
-php composer.phar install --prefer-source
-


### PR DESCRIPTION
- Fixed input command argument `without-signals` and `debug` to return only a boolean. Actually arguments are always false.
- Added some unit tests on command.
- Fixed pcntl extention problem : Php function `pcntl_signal_dispatch()` was always called even if we were using `without-signals`.  
