### PR TITLE
check if pcntl functions exist.

### DIFF
--- a/Command/BaseConsumerCommand.php
+++ b/Command/BaseConsumerCommand.php
@@ -63,6 +63,10 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
         }
 
         if (!AMQP_WITHOUT_SIGNALS && extension_loaded('pcntl')) {
+            if (!function_exists('pcntl_signal')) {
+                throw new \BadFunctionCallException("This function is referenced in the php.ini 'disable_functions' and can't be called.");
+            }
+
             pcntl_signal(SIGTERM, array(&$this, 'stopConsumer'));
             pcntl_signal(SIGINT, array(&$this, 'stopConsumer'));
             pcntl_signal(SIGHUP, array(&$this, 'restartConsumer'));

--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -56,6 +56,10 @@ abstract class BaseConsumer extends BaseAmqp
     protected function maybeStopConsumer()
     {
         if (extension_loaded('pcntl') && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true)) {
+            if (!function_exists('pcntl_signal_dispatch')) {
+                throw new \BadFunctionCallException("This function is referenced in the php.ini 'disable_functions' and can't be called.");
+            }
+
             pcntl_signal_dispatch();
         }
 


### PR DESCRIPTION
Check if pcntl functions exist even if the extension is loaded.
pcntl_signal and pcntl_signal_dispatch are considered as "dangerous" functions and are most of time referenced in the variable 'disable_functions' in the php.ini.

This PR will check if functions can be called. 
