### PR TITLE
Add enable_amqp parameter. Resolves #57

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
 
         $tree->root('old_sound_rabbit_mq')
             ->children()
+                ->booleanNode('enable_amqp')->defaultValue(false)->end()
                 ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->booleanNode('enable_collector')->defaultValue(false)->end()
                 ->booleanNode('sandbox')->defaultValue(false)->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -41,6 +41,10 @@ class OldSoundRabbitMqExtension extends Extension
         $configuration = new Configuration();
         $this->config = $this->processConfiguration($configuration, $configs);
 
+        if (!$this->config['enable_amqp']) {
+            return;
+        }
+
         $this->collectorEnabled = $this->config['enable_collector'];
 
         $this->loadConnections();

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Configure the `rabbitmq` service in your config:
 
 ```yaml
 old_sound_rabbit_mq:
+    enable_amqp:       true
     connections:
         default:
             host:      'localhost'


### PR DESCRIPTION
It appears to me that it's not the unavailability that we want to catch. I think the smarter way is to allow the app to be configured for ignoring the AMQP layer at all, this way I can extract the `enable_amqp` parameter into an environment specific config file depending on whether I need the queue:

In `config.yml`:

``` yaml
old_sound_rabbit_mq:
    enable_amqp:       %enable_amqp%
```

In `parameters.yml` (this file is in `.gitignore` usually):

``` yaml
parameters:
    enable_amqp: false
```

Parameter name can surely be changed to your liking. This affects the env-specific config file as well as the DI extension. 
