### PR TITLE
Fix bug when processing a message.

### DIFF
--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -14,7 +14,7 @@ class Consumer extends BaseConsumer
 
     /**
      * Set the memory limit
-     * 
+     *
      * @param int $memoryLimit
      */
     public function setMemoryLimit($memoryLimit)
@@ -24,17 +24,17 @@ class Consumer extends BaseConsumer
 
     /**
      * Get the memory limit
-     * 
+     *
      * @return int
      */
     public function getMemoryLimit()
     {
-        return $this->memoryLimit;   
+        return $this->memoryLimit;
     }
 
     /**
      * Consume the message
-     * 
+     *
      * @param int $msgAmount
      */
     public function consume($msgAmount)
@@ -54,10 +54,10 @@ class Consumer extends BaseConsumer
 
         $processFlag = call_user_func($this->callback, $msg);
 
-        if ($processFlag == ConsumerInterface::MSG_REJECT_REQUEUE) {
+        if ($processFlag === ConsumerInterface::MSG_REJECT_REQUEUE || false === $processFlag) {
             // Reject and requeue message to RabbitMQ
             $msg->delivery_info['channel']->basic_reject($msg->delivery_info['delivery_tag'], true);
-        } else if ($processFlag == ConsumerInterface::MSG_REJECT) {
+        } else if ($processFlag === ConsumerInterface::MSG_REJECT) {
             // Reject and drop
             $msg->delivery_info['channel']->basic_reject($msg->delivery_info['delivery_tag'], false);
         } else {
@@ -68,7 +68,7 @@ class Consumer extends BaseConsumer
         $this->consumed++;
         $this->maybeStopConsumer();
 
-        if (!is_null($this->getMemoryLimit()) && $this->isRamAlmostOverloaded()) {     
+        if (!is_null($this->getMemoryLimit()) && $this->isRamAlmostOverloaded()) {
             $this->stopConsuming();
         }
     }

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
+
+use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+use PhpAmqpLib\Message\AMQPMessage;
+use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
+
+class ConsumerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Check if the message is requeued or not correctly.
+     *
+     * @dataProvider processMessageProvider
+     */
+    public function testProcessMessage($processFlag, $expectedMethod, $expectedRequeue = null)
+    {
+        $amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $amqpChannel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $consumer = new Consumer($amqpConnection, $amqpChannel);
+
+        $callbackFunction = function() use ($processFlag) { return $processFlag; }; // Create a callback function with a return value set by the data provider.
+        $consumer->setCallback($callbackFunction);
+
+        // Create a default message
+        $amqpMessage = new AMQPMessage('foo body');
+        $amqpMessage->delivery_info['channel'] = $amqpChannel;
+        $amqpMessage->delivery_info['delivery_tag'] = 0;
+
+        $amqpChannel->expects($this->any())
+            ->method('basic_reject')
+            ->will($this->returnCallback(function($delivery_tag, $requeue) use ($expectedMethod, $expectedRequeue) {
+                $this->assertSame($expectedMethod, 'basic_reject'); // Check if this function should be called.
+                $this->assertSame($requeue, $expectedRequeue); // Check if the message should be requeued.
+            }));
+
+        $amqpChannel->expects($this->any())
+            ->method('basic_ack')
+            ->will($this->returnCallback(function($delivery_tag) use ($expectedMethod) {
+                $this->assertSame($expectedMethod, 'basic_ack'); // Check if this function should be called.
+            }));
+
+        $consumer->processMessage($amqpMessage);
+    }
+
+    public function processMessageProvider()
+    {
+        return array(
+            array(null, 'basic_ack'), // Remove message from queue only if callback return not false
+            array(true, 'basic_ack'), // Remove message from queue only if callback return not false
+            array(false, 'basic_reject', true), // Reject and requeue message to RabbitMQ
+            array(ConsumerInterface::MSG_ACK, 'basic_ack'), // Remove message from queue only if callback return not false
+            array(ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true), // Reject and requeue message to RabbitMQ
+            array(ConsumerInterface::MSG_REJECT, 'basic_reject', false), // Reject and drop
+        );
+    }
+}


### PR DESCRIPTION
The PR #109 cause a BC break : 
- when you return nothing in the callback function it requeue the message.

I fixed it and added some unit tests.

Could you please add tags for the next PR ?

Thanks.
