### PR TITLE
Added the branch alias for master and changed requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,18 @@
     }],
     "require": {
         "php"                      : ">=5.3.0",
-        "symfony/framework-bundle" : ">=2.0,<2.4",
+        "symfony/framework-bundle" : "~2.0",
         "symfony/yaml": "~2.0",
         "videlalvaro/php-amqplib"  : "2.1.*"
     },
     "require-dev": {
         "symfony/console": "~2.0"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.2.x-dev"
+        }
+    }
     "autoload": {
         "psr-0": {
             "OldSound\\RabbitMqBundle\\": ""


### PR DESCRIPTION
This will allow using the dev version to match range requirements when using the dev stability.
I decided to use 1.2.x as dev version for master because the requirement for amqplib has been bumped since 1.1.3

I also change the FrameworkBundle requirement as symfony is now keeping BC. It will be friendlier for people using cutting edge symfony (it makes it compatible with symfony master for instance)
