### PR TITLE
add idle timeout parameter to consumer

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
                             ->scalarNode('callback')->isRequired()->end()
+                            ->scalarNode('idle_timeout')->end()
                             ->arrayNode('qos_options')
                                 ->canBeUnset()
                                 ->children()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -126,6 +126,10 @@ class OldSoundRabbitMqExtension extends Extension
                 ));
             }
 
+            if(isset($consumer['idle_timeout'])) {
+                $definition->addMethodCall('setIdleTimeout', array($consumer['idle_timeout']));
+            }
+
             $this->injectConnection($definition, $consumer['connection']);
             if ($this->collectorEnabled) {
                 $this->injectLoggedChannel($definition, $key, $consumer['connection']);

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ old_sound_rabbit_mq:
             lazy:      false
     producers:
         upload_picture:
-            connection: default
+            connection:       default
             exchange_options: {name: 'upload-picture', type: direct}
     consumers:
         upload_picture:
-            connection: default
+            connection:       default
             exchange_options: {name: 'upload-picture', type: direct}
             queue_options:    {name: 'upload-picture'}
             callback:         upload_picture_service
@@ -189,7 +189,7 @@ A consumer will connect to the server and start a __loop__  waiting for incoming
 ...
     consumers:
         upload_picture:
-            connection: default
+            connection:       default
             exchange_options: {name: 'upload-picture', type: direct}
             queue_options:    {name: 'upload-picture'}
             callback:         upload_picture_service
@@ -221,6 +221,23 @@ For using command with this flag you need to install PHP with [PCNTL extension](
 If you want to establish a consumer memory limit, you can do it by using flag -l. In the following example, this flag adds 256 MB memory limit. Consumer will be stopped five MB before reaching 256MB in order to avoid a PHP Allowed memory size error.
 
 $ ./app/console rabbitmq:consumer -l 256
+
+#### Idle timeout ####
+
+If you need to set a timeout when there are no messages from your queue during a period of time, you can set the `idle_timeout` in seconds:
+
+```yaml
+...
+    consumers:
+        upload_picture:
+            connection:       default
+            exchange_options: {name: 'upload-picture', type: direct}
+            queue_options:    {name: 'upload-picture'}
+            callback:         upload_picture_service
+            idle_timeout:     60
+    ...
+```
+ 
 
 ### Callbacks ###
 

--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -14,6 +14,8 @@ abstract class BaseConsumer extends BaseAmqp
 
     protected $forceStop = false;
 
+    protected $idleTimeout = 0;
+
     public function setCallback($callback)
     {
         $this->callback = $callback;
@@ -84,5 +86,15 @@ abstract class BaseConsumer extends BaseAmqp
     public function setQosOptions($prefetchSize = 0, $prefetchCount = 0, $global = false)
     {
         $this->getChannel()->basic_qos($prefetchSize, $prefetchCount, $global);
+    }
+
+    public function setIdleTimeout($idleTimeout)
+    {
+        $this->idleTimeout = $idleTimeout;
+    }
+
+    public function getIdleTimeout()
+    {
+        return $this->idleTimeout;
     }
 }

--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -45,7 +45,7 @@ class Consumer extends BaseConsumer
 
         while (count($this->getChannel()->callbacks)) {
             $this->maybeStopConsumer();
-            $this->getChannel()->wait();
+            $this->getChannel()->wait(null, false, $this->getIdleTimeout());
         }
     }
 


### PR DESCRIPTION
In order to stop a consumer when there are no messages during a period of time you can add an `idle_timeout` parameter to you configuration.
