### PR TITLE
adds debug flag to setup-fabric command.

### DIFF
--- a/Command/SetupFabricCommand.php
+++ b/Command/SetupFabricCommand.php
@@ -3,6 +3,7 @@
 namespace OldSound\RabbitMqBundle\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SetupFabricCommand extends BaseRabbitMqCommand


### PR DESCRIPTION
Adds a debug flag to the setup-fabric command, just like it is already present on the consume command.
Useful if you need to debug the setup-fabric command.
