### PR TITLE
Added Consumer handling for single message NACK/requeue

### DIFF
--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -57,6 +57,9 @@ class Consumer extends BaseConsumer
         if ($processFlag === ConsumerInterface::MSG_REJECT_REQUEUE || false === $processFlag) {
             // Reject and requeue message to RabbitMQ
             $msg->delivery_info['channel']->basic_reject($msg->delivery_info['delivery_tag'], true);
+        } else if ($processFlag === ConsumerInterface::MSG_SINGLE_NACK_REQUEUE) {
+            // NACK and requeue message to RabbitMQ
+            $msg->delivery_info['channel']->basic_nack($msg->delivery_info['delivery_tag'], false, true);
         } else if ($processFlag === ConsumerInterface::MSG_REJECT) {
             // Reject and drop
             $msg->delivery_info['channel']->basic_reject($msg->delivery_info['delivery_tag'], false);

--- a/RabbitMq/ConsumerInterface.php
+++ b/RabbitMq/ConsumerInterface.php
@@ -12,6 +12,11 @@ interface ConsumerInterface
     const MSG_ACK = 1;
 
     /**
+     * Flag single for message nack and requeue
+     */
+    const MSG_SINGLE_NACK_REQUEUE = 2;
+
+    /**
      * Flag for reject and requeue
      */
     const MSG_REJECT_REQUEUE = 0;


### PR DESCRIPTION
When using ConsumerInterface::MSG_REJECT_REQUEUE, the message will requeue but will not be redelivered to the same consumer. This can cause messages to get stuck in a one consumer configuration. Using NACK/requeue, the message is requeued and will be redelivered back to the same consumer once again. This behavior is strange... afaik, on an AMQP level, there are no differences between a reject and a single message nack.
