### PR TITLE
Adding timeout to RPC call when waiting for replies

### DIFF
--- a/RabbitMq/RpcClient.php
+++ b/RabbitMq/RpcClient.php
@@ -31,12 +31,12 @@ class RpcClient extends BaseAmqp
         $this->requests++;
     }
 
-    public function getReplies()
+    public function getReplies($timeout = 0)
     {
         $this->getChannel()->basic_consume($this->queueName, '', false, true, false, false, array($this, 'processMessage'));
 
         while (count($this->replies) < $this->requests) {
-            $this->getChannel()->wait();
+            $this->getChannel()->wait(null, false, $timeout);
         }
 
         $this->getChannel()->basic_cancel($this->queueName);


### PR DESCRIPTION
Using RPC calls, I have run into issues if the server fails to produce a return message, the php continues to wait locking up an apache thread and littering RabbitMq with temporary queues until apache is restarted.

This patch adds the ability to pass in a timeout for waiting for a message in the temporary queue. 
