### PR TITLE
Allow multiple sequential rpc requests

### DIFF
--- a/RabbitMq/RpcClient.php
+++ b/RabbitMq/RpcClient.php
@@ -40,6 +40,7 @@ class RpcClient extends BaseAmqp
         }
 
         $this->getChannel()->basic_cancel($this->queueName);
+        $this->requests = 0;
 
         return $this->replies;
     }


### PR DESCRIPTION
With a same client, I would like to launch mulitple RPC queries in a row:

``` php
$rpc->addRequest(serialize($msg), 'server', $action);
$replies = $rpc->getReplies();

// then
$rpc->addRequest(serialize($msg), 'server', $action);
$replies = $rpc->getReplies();
```

Without this patch, $this->requests is increasing without ever decreasing, preventing the second series of requests to never end, always waiting for new replies.

In theory, I can just launch new RPC client, but why lose an open connexion?
