### PR TITLE
[Proposition] A consumer should be able to bind multiple queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,23 @@ old_sound_rabbit_mq:
     producers:
         upload_picture:
             connection:       default
-            exchange_options: {name: 'upload-picture', type: direct}
+            exchange_options: {name: 'picture', type: direct}
     consumers:
+        picture_stuff:
+            queues:
+                - upload_picture
+                - resize_picture
+    queues:
         upload_picture:
             connection:       default
-            exchange_options: {name: 'upload-picture', type: direct}
+            exchange_options: {name: 'picture', type: direct}
             queue_options:    {name: 'upload-picture'}
-            callback:         upload_picture_service
+            callback:         upload_picture_service   
+        resize_picture:
+            connection:       default
+            exchange_options: {name: 'picture', type: direct}
+            queue_options:    {name: 'resize-picture'}
+            callback:         resize_picture_service        
 ```
 
 Here we configure the connection service and the message endpoints that our application will have. In this example your service container will contain the service `old_sound_rabbit_mq.upload_picture_producer` and `old_sound_rabbit_mq.upload_picture_consumer`. The later expects that there's a service called `upload_picture_service`.


### PR DESCRIPTION
A consumer is tied to only one queue in the current implementation, which is a "RabbitMqBundle / Thumper" limitation but not a rabbitmq one. I already implemented it based on php-amqplib, but before coding everything in this repo, I just wanted to check if it seems interesting to other people.

The advantage is quite clear for me: I've a lot of "stuff that are not really that important but must be done someday". For that, I like to have "generic consumer" that are coupled with multiple queues and handle message one by one, coming from any of theses queues. It's a way better scalable architecture as I can launch multiple of these generic consumer instead of launching many of each queue.

The one "problem" I have is to be sure that all the queues of a single consumer are connected to the same exchange, and that can be verified on compilation time.

So… this is just documentation for now, to clarified the need and the how. Thanks.
