### PR TITLE
reset replies for subsequent requests

### DIFF
--- a/RabbitMq/RpcClient.php
+++ b/RabbitMq/RpcClient.php
@@ -33,6 +33,7 @@ class RpcClient extends BaseAmqp
 
     public function getReplies()
     {
+        $this->replies = array();
         $this->getChannel()->basic_consume($this->queueName, '', false, true, false, false, array($this, 'processMessage'));
 
         while (count($this->replies) < $this->requests) {
@@ -41,10 +42,8 @@ class RpcClient extends BaseAmqp
 
         $this->getChannel()->basic_cancel($this->queueName);
         $this->requests = 0;
-        $replies = $this->replies;
-        $this->replies = array();
 
-        return $replies;
+        return $this->replies;
     }
 
     public function processMessage(AMQPMessage $msg)


### PR DESCRIPTION
This is related to #152

If we don't reset the replies array when everything has been received, the 2nd call to `$rpcClient->getReplies()` will immediately return the `$this->replies` with its previous values as `count($this->replies)` will be > `$this->requests` (if the previous batch had as many or more requests than the current one)
