### PR TITLE
Use channel accessor

### DIFF
--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -54,7 +54,7 @@ class Consumer extends BaseConsumer
      */
     public function purge()
     {
-        $this->ch->queue_purge($this->queueOptions['name'], true);
+        $this->getChannel()->queue_purge($this->queueOptions['name'], true);
     }
 
     public function processMessage(AMQPMessage $msg)


### PR DESCRIPTION
The accessor instanciate the channel on the first call, so this was producing a bug when purge was called before any other function calling getChannel().
