### PR TITLE
Give more details when function is disabled in php.ini

### DIFF
--- a/Command/BaseConsumerCommand.php
+++ b/Command/BaseConsumerCommand.php
@@ -63,7 +63,7 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
 
         if (!AMQP_WITHOUT_SIGNALS && extension_loaded('pcntl')) {
             if (!function_exists('pcntl_signal')) {
-                throw new \BadFunctionCallException("This function is referenced in the php.ini 'disable_functions' and can't be called.");
+                throw new \BadFunctionCallException("Function 'pcntl_signal' is referenced in the php.ini 'disable_functions' and can't be called.");
             }
 
             pcntl_signal(SIGTERM, array(&$this, 'stopConsumer'));

--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -49,7 +49,7 @@ abstract class BaseConsumer extends BaseAmqp
     {
         if (extension_loaded('pcntl') && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true)) {
             if (!function_exists('pcntl_signal_dispatch')) {
-                throw new \BadFunctionCallException("This function is referenced in the php.ini 'disable_functions' and can't be called.");
+                throw new \BadFunctionCallException("Function 'pcntl_signal_dispatch' is referenced in the php.ini 'disable_functions' and can't be called.");
             }
 
             pcntl_signal_dispatch();


### PR DESCRIPTION
Currently, if a function is disabled in `php.ini` file, the output is the following:

> [BadFunctionCallException]
> This function is referenced in the php.ini 'disable_functions' and can't be called.  

This PR changes the exception message to give the disabled function name:

> [BadFunctionCallException]
> Function 'pcntl_signal' is referenced in the php.ini 'disable_functions' and can't be called.
