### PR TITLE
Producer without explicit exchange definition defaults to AMQP Default Exchange

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -207,7 +207,6 @@ class Configuration implements ConfigurationInterface
         $node = new ArrayNodeDefinition('exchange_options');
 
         return $node
-            ->isRequired()
             ->children()
                 ->scalarNode('name')->isRequired()->end()
                 ->scalarNode('type')->isRequired()->end()
@@ -216,6 +215,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('auto_delete')->defaultValue(false)->end()
                 ->booleanNode('internal')->defaultValue(false)->end()
                 ->booleanNode('nowait')->defaultValue(false)->end()
+                ->booleanNode('declare')->defaultValue(true)->end()
                 ->variableNode('arguments')->defaultNull()->end()
                 ->scalarNode('ticket')->defaultNull()->end()
             ->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -93,6 +93,13 @@ class OldSoundRabbitMqExtension extends Extension
                 $definition = new Definition($producer['class']);
                 $definition->addTag('old_sound_rabbit_mq.base_amqp');
                 $definition->addTag('old_sound_rabbit_mq.producer');
+                //this producer doesn't define an exchange -> using AMQP Default
+                if (!isset($producer['exchange_options'])) {
+                    $producer['exchange_options']['name'] = '';
+                    $producer['exchange_options']['type'] = 'direct';
+                    $producer['exchange_options']['passive'] = true;
+                    $producer['exchange_options']['declare'] = false;
+                }
                 $definition->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($producer['exchange_options'])));
                 //this producer doesn't define a queue
                 if (!isset($producer['queue_options'])) {

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -23,7 +23,8 @@ abstract class BaseAmqp
         'internal' => false,
         'nowait' => false,
         'arguments' => null,
-        'ticket' => null
+        'ticket' => null,
+        'declare' => true,
     );
 
     protected $queueOptions = array(
@@ -96,7 +97,7 @@ abstract class BaseAmqp
      */
     public function setExchangeOptions(array $options = array())
     {
-        if (empty($options['name'])) {
+        if (!isset($options['name'])) {
             throw new \InvalidArgumentException('You must provide an exchange name');
         }
 
@@ -127,18 +128,20 @@ abstract class BaseAmqp
 
     protected function exchangeDeclare()
     {
-        $this->getChannel()->exchange_declare(
-            $this->exchangeOptions['name'],
-            $this->exchangeOptions['type'],
-            $this->exchangeOptions['passive'],
-            $this->exchangeOptions['durable'],
-            $this->exchangeOptions['auto_delete'],
-            $this->exchangeOptions['internal'],
-            $this->exchangeOptions['nowait'],
-            $this->exchangeOptions['arguments'],
-            $this->exchangeOptions['ticket']);
+        if ($this->exchangeOptions['declare']) {
+            $this->getChannel()->exchange_declare(
+                $this->exchangeOptions['name'],
+                $this->exchangeOptions['type'],
+                $this->exchangeOptions['passive'],
+                $this->exchangeOptions['durable'],
+                $this->exchangeOptions['auto_delete'],
+                $this->exchangeOptions['internal'],
+                $this->exchangeOptions['nowait'],
+                $this->exchangeOptions['arguments'],
+                $this->exchangeOptions['ticket']);
 
-        $this->exchangeDeclared = true;
+            $this->exchangeDeclared = true;
+        }
     }
 
     protected function queueDeclare()

--- a/Tests/DependencyInjection/Fixtures/no_exchange_options.yml
+++ b/Tests/DependencyInjection/Fixtures/no_exchange_options.yml
@@ -1,0 +1,8 @@
+old_sound_rabbit_mq:
+
+    connections:
+        default:
+
+    producers:
+        producer:
+            connection: default

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -75,6 +75,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'nowait'      => true,
                             'arguments'   => null,
                             'ticket'      => null,
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -114,6 +115,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'nowait'      => false,
                             'arguments'   => null,
                             'ticket'      => null,
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -153,6 +155,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'nowait'      => true,
                             'arguments'   => null,
                             'ticket'      => null,
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -204,6 +207,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'nowait'      => false,
                             'arguments'   => null,
                             'ticket'      => null,
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -279,6 +283,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'nowait'      => false,
                             'arguments'   => null,
                             'ticket'      => null,
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -343,6 +348,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'nowait'      => true,
                             'arguments'   => null,
                             'ticket'      => null,
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -378,6 +384,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'nowait'      => false,
                             'arguments'   => null,
                             'ticket'      => null,
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -497,6 +504,21 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('setExchangeOptions', $calls[0][0]);
         $options = $calls[0][1];
         $this->assertEquals(array('name' => 'bar'), $options[0]['arguments']);
+    }
+
+    public function testProducerWithoutExplicitExchangeOptionsConnectsToAMQPDefault()
+    {
+        $container = $this->getContainer('no_exchange_options.yml');
+
+        $definition = $container->getDefinition('old_sound_rabbit_mq.producer_producer');
+        $calls = $definition->getMethodCalls();
+        $this->assertEquals('setExchangeOptions', $calls[0][0]);
+        $options = $calls[0][1];
+
+        $this->assertEquals('', $options[0]['name']);
+        $this->assertEquals('direct', $options[0]['type']);
+        $this->assertEquals(false, $options[0]['declare']);
+        $this->assertEquals(true, $options[0]['passive']);
     }
 
     private function getContainer($file, $debug = false)


### PR DESCRIPTION
This PR adds functionality that in case no `exchange_options` is passed to a producer configuration block, the bundle uses AMQP Default Exchange (see https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default). Fixes #182.
