### PR TITLE
Set rpc client connexion to be lazy

### DIFF
--- a/RabbitMq/RpcClient.php
+++ b/RabbitMq/RpcClient.php
@@ -9,13 +9,13 @@ class RpcClient extends BaseAmqp
 {
     protected $requests = 0;
     protected $replies = array();
-    protected $queueName;
     protected $expectSerializedResponse;
     protected $timeout = 0;
 
+    private $queueName;
+
     public function initClient($expectSerializedResponse = true)
     {
-        list($this->queueName, ,) = $this->getChannel()->queue_declare("", false, false, true, true);
         $this->expectSerializedResponse = $expectSerializedResponse;
     }
 
@@ -26,7 +26,7 @@ class RpcClient extends BaseAmqp
         }
 
         $msg = new AMQPMessage($msgBody, array('content_type' => 'text/plain',
-                                               'reply_to' => $this->queueName,
+                                               'reply_to' => $this->getQueueName(),
                                                'delivery_mode' => 1, // non durable
                                                'expiration' => $expiration*1000,
                                                'correlation_id' => $requestId));
@@ -43,13 +43,13 @@ class RpcClient extends BaseAmqp
     public function getReplies()
     {
         $this->replies = array();
-        $this->getChannel()->basic_consume($this->queueName, '', false, true, false, false, array($this, 'processMessage'));
+        $this->getChannel()->basic_consume($this->getQueueName(), '', false, true, false, false, array($this, 'processMessage'));
 
         while (count($this->replies) < $this->requests) {
             $this->getChannel()->wait(null, false, $this->timeout);
         }
 
-        $this->getChannel()->basic_cancel($this->queueName);
+        $this->getChannel()->basic_cancel($this->getQueueName());
         $this->requests = 0;
         $this->timeout = 0;
 
@@ -64,5 +64,14 @@ class RpcClient extends BaseAmqp
         }
 
         $this->replies[$msg->get('correlation_id')] = $messageBody;
+    }
+    
+    protected function getQueueName()
+    {
+        if (null === $this->queueName) {
+            list($this->queueName, ,) = $this->getChannel()->queue_declare("", false, false, true, true);
+        }
+
+        return $this->queueName;
     }
 }


### PR DESCRIPTION
Actually, each time a rpc client service with rabbitmq is construct, a connexion to RabbitMqServer is launched as the extension add a method call to initClient in the container.

Sometimes the rpc client is loaded but not used (for our case we use it in the security context but if user is anonymous we never make a call to rpc)

This is a BC break for people using this class with the queuename member as it's no longer protected (user should use getQueueName function instead of the queuename variable)
