### PR TITLE
adding reconnect method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+- 2014-07-21
+    * Added `reconnect` method into `OldSound\RabbitMqBundle\RabbitMq\BaseAmqp`
+
 - 2014-02-24
     * Add a parameter to RPC client configuration to disable auto unserialize when adding call results to results array.
 

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -15,7 +15,7 @@ abstract class BaseAmqp
     protected $routingKey = '';
     protected $autoSetupFabric = true;
     protected $basicProperties = array('content_type' => 'text/plain', 'delivery_mode' => 2);
-	
+
     protected $exchangeOptions = array(
         'passive' => false,
         'durable' => true,
@@ -64,6 +64,15 @@ abstract class BaseAmqp
         if ($this->conn->isConnected()) {
             $this->conn->close();
         }
+    }
+
+    public function reconnect()
+    {
+        if (!$this->conn->isConnected()) {
+            return;
+        }
+
+        $this->conn->reconnect();
     }
 
     /**


### PR DESCRIPTION
Starting from `v2.3.0` `videlalvaro/php-amqplib` has ability to reconnect, it was implemented on 2013-06-10, but now it's 2014-07-21 and bundle still doesn't have ability to do that.
