### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "1.6.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
1.5.0 is already released, so dev-master is not likely to be 1.2.x
