### PR TITLE
install composer shows old version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Require the bundle in your composer.json file:
 ````
 {
     "require": {
-        "oldsound/rabbitmq-bundle": "1.3.*",
+        "oldsound/rabbitmq-bundle": "1.*",
     }
 }
 ```


### PR DESCRIPTION
Not sure what the right argument would be here but requiring 1.3.\* when you have 1.5 seems weird
