### PR TITLE
Added fixing the xml config for most configuration options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
     protected function addConnections(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('connection')
             ->children()
                 ->arrayNode('connections')
                     ->useAttributeAsKey('key')
@@ -63,6 +64,7 @@ class Configuration implements ConfigurationInterface
     protected function addProducers(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('producer')
             ->children()
                 ->arrayNode('producers')
                     ->canBeUnset()
@@ -84,6 +86,7 @@ class Configuration implements ConfigurationInterface
     protected function addConsumers(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('consumer')
             ->children()
                 ->arrayNode('consumers')
                     ->canBeUnset()
@@ -114,6 +117,7 @@ class Configuration implements ConfigurationInterface
     protected function addMultipleConsumers(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('multiple_consumer')
             ->children()
                 ->arrayNode('multiple_consumers')
                 ->canBeUnset()
@@ -142,6 +146,7 @@ class Configuration implements ConfigurationInterface
     protected function addAnonConsumers(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('anon_consumer')
             ->children()
                 ->arrayNode('anon_consumers')
                     ->canBeUnset()
@@ -161,6 +166,7 @@ class Configuration implements ConfigurationInterface
     protected function addRpcClients(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('rpc_client')
             ->children()
                 ->arrayNode('rpc_clients')
                     ->canBeUnset()
@@ -179,6 +185,7 @@ class Configuration implements ConfigurationInterface
     protected function addRpcServers(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('rpc_server')
             ->children()
                 ->arrayNode('rpc_servers')
                     ->canBeUnset()


### PR DESCRIPTION
This allows things to be specified in xml as:

```
<rabbitmq:consumer>...</rabbitmq:consumer>
<rabbitmq:consumer>...</rabbitmq:consumer>
```

instead of:

```
<rabbitmq:consumers>...</rabbitmq:consumers>
<rabbitmq:consumers>...</rabbitmq:consumers>
```

It appears the the queues option in multiple_consumers might have the same issue but I am unsure how to fix it because fixXmlConfig() doesn't appear to affect it when I tried adding it.

Fixes #197.
