### PR TITLE
Code robustness

### DIFF
--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -61,7 +61,7 @@ abstract class BaseAmqp
             $this->ch->close();
         }
         
-        if ($this->conn->isConnected()) {
+        if ($this->conn && $this->conn->isConnected()) {
             $this->conn->close();
         }
     }


### PR DESCRIPTION
BaseAmqp __destruct did not check $conn before calling some method on it.
