### PR TITLE
Added multiple consumer queues provider support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+- 2014-11-27
+    * Added interface `OldSound\RabbitMqBundle\Provider\QueuesProviderInterface`
+    * Added `queues_provider` configuration for multiple consumer
+
 - 2014-07-21
     * Added `reconnect` method into `OldSound\RabbitMqBundle\RabbitMq\BaseAmqp`
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -139,6 +139,7 @@ class Configuration implements ConfigurationInterface
                                 ->booleanNode('global')->defaultFalse()->end()
                             ->end()
                         ->end()
+                        ->scalarNode('queues_provider')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end()
@@ -243,7 +244,7 @@ class Configuration implements ConfigurationInterface
     protected function getMultipleQueuesConfiguration()
     {
         $node = new ArrayNodeDefinition('queues');
-        $prototypeNode = $node->requiresAtLeastOneElement()->prototype('array');
+        $prototypeNode = $node->prototype('array');
 
         $this->addQueueNodeConfiguration($prototypeNode);
 

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -173,6 +173,13 @@ class OldSoundRabbitMqExtension extends Extension
         foreach ($this->config['multiple_consumers'] as $key => $consumer) {
             $queues = array();
 
+            if (empty($consumer['queues']) && empty($consumer['queues_provider'])) {
+                throw new InvalidConfigurationException(
+                    "Error on loading $key multiple consumer. " .
+                    "Either 'queues' or 'queues_provider' parameters should be defined."
+                );
+            }
+
             foreach ($consumer['queues'] as $queueName => $queueOptions) {
                 $queues[$queueOptions['name']]  = $queueOptions;
                 $queues[$queueOptions['name']]['callback'] = array(new Reference($queueOptions['callback']), 'execute');
@@ -184,6 +191,13 @@ class OldSoundRabbitMqExtension extends Extension
                 ->addTag('old_sound_rabbit_mq.multi_consumer')
                 ->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($consumer['exchange_options'])))
                 ->addMethodCall('setQueues', array($this->normalizeArgumentKeys($queues)));
+
+            if ($consumer['queues_provider']) {
+                $definition->addMethodCall(
+                    'setQueuesProvider',
+                    array(new Reference($consumer['queues_provider']))
+                );
+            }
 
             if (array_key_exists('qos_options', $consumer)) {
                 $definition->addMethodCall('setQosOptions', array(

--- a/Provider/QueuesProviderInterface.php
+++ b/Provider/QueuesProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Provider;
+
+/**
+ * Queues provider interface
+ *
+ * @author Sergey Chernecov <sergey.chernecov@intexsys.lv>
+ */
+interface QueuesProviderInterface
+{
+    /**
+     * Return array of queues
+     *
+     * @return array
+     */
+    public function getQueues();
+}

--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ multiple_consumers:
     upload:
         connection:       default
         exchange_options: {name: 'upload', type: direct}
+        queues_provider: queues_provider_service
         queues:
             upload-picture:
                 name:     upload_picture
@@ -507,6 +508,9 @@ The callback is now specified under each queues and must implement the `Consumer
 All the options of `queues-options` in the consumer are available for each queue.
 
 Be aware that all queues are under the same exchange, it's up to you to set the correct routing for callbacks.
+
+The `queues_provider` is a optional service that dynamically provides queues.
+It must implement `QueuesProviderInterface`
 
 ### Anonymous Consumers ###
 

--- a/Tests/DependencyInjection/Fixtures/test.yml
+++ b/Tests/DependencyInjection/Fixtures/test.yml
@@ -112,6 +112,7 @@ old_sound_rabbit_mq:
                       - 'android.upload'
                       - 'iphone.upload'
                     callback:        foo.multiple_test2.callback
+            queues_provider: foo.queues_provider
 
     anon_consumers:
         foo_anon_consumer:

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -320,6 +320,12 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             )
                         )
                     )
+                ),
+                array(
+                    'setQueuesProvider',
+                    array(
+                        new Reference('foo.queues_provider')
+                    )
                 )
             ),
             $definition->getMethodCalls()

--- a/Tests/RabbitMq/MultipleConsumerTest.php
+++ b/Tests/RabbitMq/MultipleConsumerTest.php
@@ -2,12 +2,48 @@
 
 namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 
+use OldSound\RabbitMqBundle\Provider\QueuesProviderInterface;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Multiple consumer
+     *
+     * @var MultipleConsumer
+     */
+    private $multipleConsumer;
+
+    /**
+     * AMQP channel
+     *
+     * @var \PHPUnit_Framework_MockObject_MockObject|AMQPChannel
+     */
+    private $amqpChannel;
+
+    /**
+     * AMQP connection
+     *
+     * @var \PHPUnit_Framework_MockObject_MockObject|AMQPConnection
+     */
+    private $amqpConnection;
+
+    /**
+     * Set up
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->amqpConnection = $this->prepareAMQPConnection();
+        $this->amqpChannel = $this->prepareAMQPChannel();
+        $this->multipleConsumer = new MultipleConsumer($this->amqpConnection, $this->amqpChannel);
+    }
+
     /**
      * Check if the message is requeued or not correctly.
      *
@@ -15,40 +51,115 @@ class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessMessage($processFlag, $expectedMethod, $expectedRequeue = null)
     {
-        $amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $callback = $this->prepareCallback($processFlag);
 
-        $amqpChannel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->multipleConsumer->setQueues(
+            array(
+                'test-1' => array('callback' => $callback),
+                'test-2' => array('callback' => $callback)
+            )
+        );
 
-        $consumer = new MultipleConsumer($amqpConnection, $amqpChannel);
-        $callback = function($msg) use (&$lastQueue, $processFlag) {
-            return $processFlag;
-        };
-
-        $consumer->setQueues(array('test-1' => array('callback' => $callback), 'test-2'  => array('callback' => $callback)));
+        $this->prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue);
 
         // Create a default message
         $amqpMessage = new AMQPMessage('foo body');
-        $amqpMessage->delivery_info['channel'] = $amqpChannel;
+        $amqpMessage->delivery_info['channel'] = $this->amqpChannel;
         $amqpMessage->delivery_info['delivery_tag'] = 0;
-        $amqpChannel->expects($this->any())
-            ->method('basic_reject')
-            ->will($this->returnCallback(function($delivery_tag, $requeue) use ($expectedMethod, $expectedRequeue) {
-                \PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_reject'); // Check if this function should be called.
-                \PHPUnit_Framework_Assert::assertSame($requeue, $expectedRequeue); // Check if the message should be requeued.
-            }));
 
-        $amqpChannel->expects($this->any())
-            ->method('basic_ack')
-            ->will($this->returnCallback(function($delivery_tag) use ($expectedMethod) {
-                \PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_ack'); // Check if this function should be called.
-            }));
+        $this->multipleConsumer->processQueueMessage('test-1', $amqpMessage);
+        $this->multipleConsumer->processQueueMessage('test-2', $amqpMessage);
+    }
 
-        $consumer->processQueueMessage('test-1', $amqpMessage);
-        $consumer->processQueueMessage('test-2', $amqpMessage);
+    /**
+     * Check queues provider works well
+     *
+     * @dataProvider processMessageProvider
+     */
+    public function testQueuesProvider($processFlag, $expectedMethod, $expectedRequeue = null)
+    {
+        $callback = $this->prepareCallback($processFlag);
+
+        $queuesProvider = $this->prepareQueuesProvider();
+        $queuesProvider->expects($this->once())
+            ->method('getQueues')
+            ->will($this->returnValue(
+                array(
+                    'test-1' => array('callback' => $callback),
+                    'test-2' => array('callback' => $callback)
+                )
+            ));
+
+        $this->multipleConsumer->setQueuesProvider($queuesProvider);
+
+        /**
+         * We don't test consume method, which merges queues by calling $this->setupConsumer();
+         * So we need to invoke it manually
+         */
+        $reflectionClass = new \ReflectionClass(get_class($this->multipleConsumer));
+        $reflectionMethod = $reflectionClass->getMethod('mergeQueues');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($this->multipleConsumer);
+
+        $this->prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue);
+
+        // Create a default message
+        $amqpMessage = new AMQPMessage('foo body');
+        $amqpMessage->delivery_info['channel'] = $this->amqpChannel;
+        $amqpMessage->delivery_info['delivery_tag'] = 0;
+
+        $this->multipleConsumer->processQueueMessage('test-1', $amqpMessage);
+        $this->multipleConsumer->processQueueMessage('test-2', $amqpMessage);
+    }
+
+    /**
+     * Check queues provider works well with static queues together
+     *
+     * @dataProvider processMessageProvider
+     */
+    public function testQueuesProviderAndStaticQueuesTogether($processFlag, $expectedMethod, $expectedRequeue = null)
+    {
+        $callback = $this->prepareCallback($processFlag);
+
+        $this->multipleConsumer->setQueues(
+            array(
+                'test-1' => array('callback' => $callback),
+                'test-2' => array('callback' => $callback)
+            )
+        );
+
+        $queuesProvider = $this->prepareQueuesProvider();
+        $queuesProvider->expects($this->once())
+            ->method('getQueues')
+            ->will($this->returnValue(
+                array(
+                    'test-3' => array('callback' => $callback),
+                    'test-4' => array('callback' => $callback)
+                )
+            ));
+
+        $this->multipleConsumer->setQueuesProvider($queuesProvider);
+
+        /**
+         * We don't test consume method, which merges queues by calling $this->setupConsumer();
+         * So we need to invoke it manually
+         */
+        $reflectionClass = new \ReflectionClass(get_class($this->multipleConsumer));
+        $reflectionMethod = $reflectionClass->getMethod('mergeQueues');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($this->multipleConsumer);
+
+        $this->prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue);
+
+        // Create a default message
+        $amqpMessage = new AMQPMessage('foo body');
+        $amqpMessage->delivery_info['channel'] = $this->amqpChannel;
+        $amqpMessage->delivery_info['delivery_tag'] = 0;
+
+        $this->multipleConsumer->processQueueMessage('test-1', $amqpMessage);
+        $this->multipleConsumer->processQueueMessage('test-2', $amqpMessage);
+        $this->multipleConsumer->processQueueMessage('test-3', $amqpMessage);
+        $this->multipleConsumer->processQueueMessage('test-4', $amqpMessage);
     }
 
     public function processMessageProvider()
@@ -61,5 +172,77 @@ class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
             array(ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true), // Reject and requeue message to RabbitMQ
             array(ConsumerInterface::MSG_REJECT, 'basic_reject', false), // Reject and drop
         );
+    }
+
+    /**
+     * Preparing AMQP Connection
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|AMQPConnection
+     */
+    private function prepareAMQPConnection()
+    {
+        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Preparing AMQP Connection
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|AMQPChannel
+     */
+    private function prepareAMQPChannel()
+    {
+        return $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Preparing QueuesProviderInterface instance
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|QueuesProviderInterface
+     */
+    private function prepareQueuesProvider()
+    {
+        return $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueuesProviderInterface')
+            ->getMock();
+    }
+
+    /**
+     * Preparing AMQP Channel Expectations
+     *
+     * @param $expectedMethod
+     * @param $expectedRequeue
+     *
+     * @return void
+     */
+    private function prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue)
+    {
+        $this->amqpChannel->expects($this->any())
+            ->method('basic_reject')
+            ->will($this->returnCallback(function($delivery_tag, $requeue) use ($expectedMethod, $expectedRequeue) {
+                \PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_reject'); // Check if this function should be called.
+                \PHPUnit_Framework_Assert::assertSame($requeue, $expectedRequeue); // Check if the message should be requeued.
+            }));
+
+        $this->amqpChannel->expects($this->any())
+            ->method('basic_ack')
+            ->will($this->returnCallback(function($delivery_tag) use ($expectedMethod) {
+                \PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_ack'); // Check if this function should be called.
+            }));
+    }
+
+    /**
+     * Prepare callback
+     *
+     * @param $processFlag
+     * @return callable
+     */
+    private function prepareCallback($processFlag)
+    {
+        return function($msg) use (&$lastQueue, $processFlag) {
+            return $processFlag;
+        };
     }
 } 


### PR DESCRIPTION
Currently multiple consumer queues can be configured only statically in the bundle configuration. We have a use case, where specific queues can't be hard-coded (as they are being created dynamically by different agents). So, we need multiple consumer to be able to get a dynamic list of queues. In order to implement this, a queues provider can be used. It should implement a simple interface which returns array of queues (in the same format as used in configuration). The multiple consumer just merges the dynamic queues (if any) with statically configured queues, which are now optional. There is also a check in place to see if at least one of `queues` or `queues_provider` is configured.
