### PR TITLE
Default queueOptions[name] to null

### DIFF
--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -28,7 +28,7 @@ abstract class BaseAmqp
     );
 
     protected $queueOptions = array(
-        'name' => '',
+        'name' => null,
         'passive' => false,
         'durable' => true,
         'exclusive' => false,


### PR DESCRIPTION
A producer doesn't need to specify any queue options. If you don't specify queue options the default value for `queueOptions[name]` is currently an empty string. Auto setup fabric then runs queueDeclare on the producer which checks whether `queueOptions[name] !== null` to see if it needs to set up a queue. This fails with empty string and a queue with a blank name - resulting in an automatically created name by rabbitmq - is created. This ends up creating tons of unwanted queues if you keep it running for a while.

So the fix is simple, default to null for the queue name.