### PR TITLE
Allow producer to not specify any queue options

### DIFF
--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -6,12 +6,18 @@ use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
 
 abstract class BaseAmqp
-{
+{   
+    /**
+     * Queue name auto generated.
+     */
+    const QUEUE_NAME_AUTOGENERATE = '';
+
     protected $conn;
     protected $ch;
     protected $consumerTag;
     protected $exchangeDeclared = false;
     protected $queueDeclared = false;
+    protected $queueConfigured = false;
     protected $routingKey = '';
     protected $autoSetupFabric = true;
     protected $basicProperties = array('content_type' => 'text/plain', 'delivery_mode' => 2);
@@ -28,7 +34,7 @@ abstract class BaseAmqp
     );
 
     protected $queueOptions = array(
-        'name' => '',
+        'name' => self::QUEUE_NAME_AUTOGENERATE,
         'passive' => false,
         'durable' => true,
         'exclusive' => false,
@@ -121,6 +127,7 @@ abstract class BaseAmqp
     public function setQueueOptions(array $options = array())
     {
         $this->queueOptions = array_merge($this->queueOptions, $options);
+        $this->queueConfigured = true;
     }
 
     /**
@@ -152,7 +159,7 @@ abstract class BaseAmqp
 
     protected function queueDeclare()
     {
-        if (null !== $this->queueOptions['name']) {
+        if (self::QUEUE_NAME_AUTOGENERATE !== $this->queueOptions['name'] || $this->queueConfigured) {
             list($queueName, ,) = $this->getChannel()->queue_declare($this->queueOptions['name'], $this->queueOptions['passive'],
                 $this->queueOptions['durable'], $this->queueOptions['exclusive'],
                 $this->queueOptions['auto_delete'], $this->queueOptions['nowait'],


### PR DESCRIPTION
Related to the pull request https://github.com/videlalvaro/RabbitMqBundle/pull/258
This fixes the queue declaration without changing the default values of a queue. The queue should be declared only when configured.