### PR TITLE
Configuration of connection settings as URL

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -50,6 +50,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeUnset()
                     ->prototype('array')
                         ->children()
+                            ->scalarNode('url')->defaultValue('')->end()
                             ->scalarNode('host')->defaultValue('localhost')->end()
                             ->scalarNode('port')->defaultValue(5672)->end()
                             ->scalarNode('user')->defaultValue('guest')->end()

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ old_sound_rabbit_mq:
 
             #requires php_sockets.dll
             use_socket: true # default false
+        another:
+            # A different (unused) connection defined by an URL. One can omit all parts,
+            # except the scheme (amqp:). If both segment in the URL and a key value (see above)
+            # are given the value from the URL takes precedence.
+            url: 'amqp://guest:password@localhost:5672/vhost?lazy=1&connection_timeout=6'
     producers:
         upload_picture:
             connection:       default

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -33,7 +33,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             'ssl_context' => array(),
             'keepalive' => false,
             'heartbeat' => 0,
-            'use_socket' => false
+            'use_socket' => false,
+            'url' => '',
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
@@ -61,7 +62,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             ),
             'keepalive' => false,
             'heartbeat' => 0,
-            'use_socket' => false
+            'use_socket' => false,
+            'url' => '',
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
@@ -87,7 +89,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             'ssl_context' => array(),
             'keepalive' => false,
             'heartbeat' => 0,
-            'use_socket' => false
+            'use_socket' => false,
+            'url' => '',
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.lazy.connection.class%', $definition->getClass());
     }
@@ -113,7 +116,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             'ssl_context' => array(),
             'keepalive' => false,
             'heartbeat' => 0,
-            'use_socket' => false
+            'use_socket' => false,
+            'url' => '',
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
@@ -518,14 +522,14 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             $definition->getMethodCalls()
         );
     }
-    
+
     public function testDynamicConsumerDefinition()
     {
         $container = $this->getContainer('test.yml');
-        
+
         $this->assertTrue($container->has('old_sound_rabbit_mq.foo_dyn_consumer_dynamic'));
         $this->assertTrue($container->has('old_sound_rabbit_mq.bar_dyn_consumer_dynamic'));
-        
+
         $definition = $container->getDefinition('old_sound_rabbit_mq.foo_dyn_consumer_dynamic');
         $this->assertEquals(array(
                 array(

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -69,6 +69,41 @@ class AMQPConnectionFactoryTest extends \PHPUnit_Framework_TestCase
         ), $instance->constructParams);
     }
 
+    public function testSetConnectionParametersWithUrl()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection',
+            array(
+                'url' => 'amqp://bar_user:bar_password@bar_host:321/whost?keepalive=1&connection_timeout=6&read_write_timeout=6',
+                'host' => 'foo_host',
+                'port' => 123,
+                'user' => 'foo_user',
+                'password' => 'foo_password',
+                'vhost' => '/vhost',
+            )
+        );
+
+        /** @var AMQPConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection', $instance);
+        $this->assertEquals(array(
+            'bar_host',  // host
+            321,         // port
+            'bar_user',  // user
+            'bar_password', // password
+            '/whost',    // vhost
+            false,       // insist
+            "AMQPLAIN",  // login method
+            null,        // login response
+            "en_US",     // locale
+            6,           // connection timeout
+            6,           // read write timeout
+            null,        // context
+            true,       // keepalive
+            0,           // heartbeat
+        ), $instance->constructParams);
+    }
+
     public function testSSLConnectionParameters()
     {
         $factory = new AMQPConnectionFactory(


### PR DESCRIPTION
It would be nice, if I could configure the connection settings as a single string for example as an URL instead of 4 separate keys.

    //user:password@host:post/vhost