### PR TITLE
Added default exchange and queue options (v2)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -277,6 +277,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('exclusive')->defaultFalse()->end()
                 ->booleanNode('auto_delete')->defaultFalse()->end()
                 ->booleanNode('nowait')->defaultFalse()->end()
+                ->booleanNode('declare')->defaultTrue()->end()
                 ->variableNode('arguments')->defaultNull()->end()
                 ->scalarNode('ticket')->defaultNull()->end()
                 ->arrayNode('routing_keys')

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -98,15 +98,12 @@ class OldSoundRabbitMqExtension extends Extension
                 $definition->addTag('old_sound_rabbit_mq.producer');
                 //this producer doesn't define an exchange -> using AMQP Default
                 if (!isset($producer['exchange_options'])) {
-                    $producer['exchange_options']['name'] = '';
-                    $producer['exchange_options']['type'] = 'direct';
-                    $producer['exchange_options']['passive'] = true;
-                    $producer['exchange_options']['declare'] = false;
+                    $producer['exchange_options'] = $this->getDefaultExchangeOptions();
                 }
                 $definition->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($producer['exchange_options'])));
-                //this producer doesn't define a queue
+                //this producer doesn't define a queue -> using AMQP Default
                 if (!isset($producer['queue_options'])) {
-                    $producer['queue_options']['name'] = null;
+                    $producer['queue_options'] = $this->getDefaultQueueOptions();
                 }
                 $definition->addMethodCall('setQueueOptions', array($producer['queue_options']));
                 $this->injectConnection($definition, $producer['connection']);
@@ -131,12 +128,19 @@ class OldSoundRabbitMqExtension extends Extension
     {
         foreach ($this->config['consumers'] as $key => $consumer) {
             $definition = new Definition('%old_sound_rabbit_mq.consumer.class%');
-            $definition
-                ->addTag('old_sound_rabbit_mq.base_amqp')
-                ->addTag('old_sound_rabbit_mq.consumer')
-                ->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($consumer['exchange_options'])))
-                ->addMethodCall('setQueueOptions', array($this->normalizeArgumentKeys($consumer['queue_options'])))
-                ->addMethodCall('setCallback', array(array(new Reference($consumer['callback']), 'execute')));
+            $definition->addTag('old_sound_rabbit_mq.base_amqp');
+            $definition->addTag('old_sound_rabbit_mq.consumer');
+            //this consumer doesn't define an exchange -> using AMQP Default
+            if (!isset($consumer['exchange_options'])) {
+                $consumer['exchange_options'] = $this->getDefaultExchangeOptions();
+            }
+            $definition->addMethodCall('setExchangeOptions', array($this->normalizeArgumentKeys($consumer['exchange_options'])));
+            //this consumer doesn't define a queue -> using AMQP Default
+            if (!isset($consumer['queue_options'])) {
+                $consumer['queue_options'] = $this->getDefaultQueueOptions();
+            }
+            $definition->addMethodCall('setQueueOptions', array($consumer['queue_options']));
+            $definition->addMethodCall('setCallback', array(array(new Reference($consumer['callback']), 'execute')));
 
             if (array_key_exists('qos_options', $consumer)) {
                 $definition->addMethodCall('setQosOptions', array(
@@ -178,7 +182,7 @@ class OldSoundRabbitMqExtension extends Extension
             }
 
             foreach ($consumer['queues'] as $queueName => $queueOptions) {
-                $queues[$queueOptions['name']]  = $queueOptions;
+                $queues[$queueOptions['name']] = $queueOptions;
                 $queues[$queueOptions['name']]['callback'] = array(new Reference($queueOptions['callback']), 'execute');
                 $callbacks[] = new Reference($queueOptions['callback']);
             }
@@ -392,5 +396,33 @@ class OldSoundRabbitMqExtension extends Extension
         if ($refClass->implementsInterface('OldSound\RabbitMqBundle\RabbitMq\DequeuerAwareInterface')) {
             $callbackDefinition->addMethodCall('setDequeuer', array(new Reference($name)));
         }
+    }
+    
+    /**
+     * Get default AMQP exchange options
+     *
+     * @return array
+     */
+    protected function getDefaultExchangeOptions()
+    {
+        return array(
+            'name' => '',
+            'type' => 'direct',
+            'passive' => true,
+            'declare' => false
+        );
+    }
+
+    /**
+     * Get default AMQP queue options
+     *
+     * @return array
+     */
+    protected function getDefaultQueueOptions()
+    {
+        return array(
+            'name' => '',
+            'declare' => false
+        );
     }
 }

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -35,7 +35,8 @@ abstract class BaseAmqp
         'auto_delete' => false,
         'nowait' => false,
         'arguments' => null,
-        'ticket' => null
+        'ticket' => null,
+        'declare' => true,
     );
 
     /**
@@ -132,6 +133,9 @@ abstract class BaseAmqp
         $this->routingKey = $routingKey;
     }
 
+    /**
+     * Declares exchange
+     */
     protected function exchangeDeclare()
     {
         if ($this->exchangeOptions['declare']) {
@@ -150,9 +154,12 @@ abstract class BaseAmqp
         }
     }
 
+    /**
+     * Declares queue, creates if needed
+     */
     protected function queueDeclare()
     {
-        if (null !== $this->queueOptions['name']) {
+        if ($this->queueOptions['declare']) {
             list($queueName, ,) = $this->getChannel()->queue_declare($this->queueOptions['name'], $this->queueOptions['passive'],
                 $this->queueOptions['durable'], $this->queueOptions['exclusive'],
                 $this->queueOptions['auto_delete'], $this->queueOptions['nowait'],
@@ -160,13 +167,28 @@ abstract class BaseAmqp
 
             if (isset($this->queueOptions['routing_keys']) && count($this->queueOptions['routing_keys']) > 0) {
                 foreach ($this->queueOptions['routing_keys'] as $routingKey) {
-                    $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $routingKey);
+                    $this->queueBind($queueName, $this->exchangeOptions['name'], $routingKey);
                 }
             } else {
-                $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $this->routingKey);
+                $this->queueBind($queueName, $this->exchangeOptions['name'], $this->routingKey);
             }
 
             $this->queueDeclared = true;
+        }
+    }
+
+    /**
+     * Binds queue to an exchange
+     *
+     * @param string $queue
+     * @param string $exchange
+     * @param string $routing_key
+     */
+    protected function queueBind($queue, $exchange, $routing_key)
+    {
+        // queue binding is not permitted on the default exchange
+        if ('' !== $exchange) {
+            $this->getChannel()->queue_bind($queue, $exchange, $routing_key);
         }
     }
 

--- a/RabbitMq/MultipleConsumer.php
+++ b/RabbitMq/MultipleConsumer.php
@@ -68,10 +68,10 @@ class MultipleConsumer extends Consumer
 
             if (isset($options['routing_keys']) && count($options['routing_keys']) > 0) {
                 foreach ($options['routing_keys'] as $routingKey) {
-                    $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $routingKey);
+                    $this->queueBind($queueName, $this->exchangeOptions['name'], $routingKey);
                 }
             } else {
-                $this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $this->routingKey);
+                $this->queueBind($queueName, $this->exchangeOptions['name'], $this->routingKey);
             }
         }
 

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -143,7 +143,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                     'setQueueOptions',
                     array(
                         array(
-                            'name'        => null,
+                            'name'        => '',
+                            'declare'     => false,
                         )
                     )
                 )
@@ -183,7 +184,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                     'setQueueOptions',
                     array(
                         array(
-                            'name'        => null,
+                            'name'        => '',
+                            'declare'     => false,
                         )
                     )
                 )
@@ -232,6 +234,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'arguments'    => null,
                             'ticket'       => null,
                             'routing_keys' => array('android.#.upload', 'iphone.upload'),
+                            'declare'      => true,
                         )
                     )
                 ),
@@ -284,6 +287,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                             'arguments'   => null,
                             'ticket'      => null,
                             'routing_keys' => array(),
+                            'declare'     => true,
                         )
                     )
                 ),
@@ -361,7 +365,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                                 'arguments'    => null,
                                 'ticket'       => null,
                                 'routing_keys' => array(),
-                                'callback'     => array(new Reference('foo.multiple_test1.callback'), 'execute')
+                                'callback'     => array(new Reference('foo.multiple_test1.callback'), 'execute'),
+                                'declare'      => true,
                             ),
                             'foo_bar_2' => array(
                                 'name'         => 'foo_bar_2',
@@ -376,7 +381,8 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                                     'android.upload',
                                     'iphone.upload'
                                 ),
-                                'callback'     => array(new Reference('foo.multiple_test2.callback'), 'execute')
+                                'callback'     => array(new Reference('foo.multiple_test2.callback'), 'execute'),
+                                'declare'      => true,
                             )
                         )
                     )
@@ -557,6 +563,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
                     'arguments'    => null,
                     'ticket'       => null,
                     'routing_keys' => array(),
+                    'declare'      => true,
                 ))),
                 array('setSerializer', array('serialize')),
             ),


### PR DESCRIPTION
I rewrote the previous pull request #257 
It is also similar to #269 and #258

I modified consumer configuration to allow consumers without exchange options

for example : 

```yaml
    producers:
        hello:
            connection:       default
    consumers:
        hello:
            connection:       default
            exchange_options: { name: 'amq.direct', type: direct }
            queue_options:    { name: 'hello' }
            callback:         hello_consumer
```

Can be writen like this : 
```yaml
    producers:
        hello:
            connection:       default
    consumers:
        hello:
            connection:       default
            queue_options:    { name: 'hello' }
            callback:         hello_consumer
```

In my case, the hello producer uses default exchange and direct queuing and the consumer exchange is useless