### PR TITLE
Arbitrary Bindings

### DIFF
--- a/Command/SetupFabricCommand.php
+++ b/Command/SetupFabricCommand.php
@@ -28,8 +28,11 @@ class SetupFabricCommand extends BaseRabbitMqCommand
 
         $partsHolder = $this->getContainer()->get('old_sound_rabbit_mq.parts_holder');
 
-        foreach ($partsHolder->getParts('old_sound_rabbit_mq.base_amqp') as $baseAmqp) {
-            $baseAmqp->setupFabric();
+        foreach (array('base_amqp', 'binding') as $key) {
+            foreach ($partsHolder->getParts('old_sound_rabbit_mq.' . $key) as $baseAmqp) {
+                $baseAmqp->setupFabric();
+            }
         }
+
     }
 }

--- a/DependencyInjection/Compiler/RegisterPartsPass.php
+++ b/DependencyInjection/Compiler/RegisterPartsPass.php
@@ -18,6 +18,7 @@ class RegisterPartsPass implements CompilerPassInterface
 
         $tags = array(
             'old_sound_rabbit_mq.base_amqp',
+            'old_sound_rabbit_mq.binding',
             'old_sound_rabbit_mq.producer',
             'old_sound_rabbit_mq.consumer',
             'old_sound_rabbit_mq.multi_consumer',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
         ;
 
         $this->addConnections($rootNode);
+        $this->addBindings($rootNode);
         $this->addProducers($rootNode);
         $this->addConsumers($rootNode);
         $this->addMultipleConsumers($rootNode);
@@ -71,6 +72,7 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
+
     protected function addProducers(ArrayNodeDefinition $node)
     {
         $node
@@ -86,6 +88,30 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('connection')->defaultValue('default')->end()
                             ->scalarNode('auto_setup_fabric')->defaultTrue()->end()
                             ->scalarNode('class')->defaultValue('%old_sound_rabbit_mq.producer.class%')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    protected function addBindings(ArrayNodeDefinition $node)
+    {
+        $node
+            ->fixXmlConfig('binding')
+            ->children()
+                ->arrayNode('bindings')
+                    ->canBeUnset()
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('connection')->defaultValue('default')->end()
+                            ->scalarNode('exchange')->defaultNull()->end()
+                            ->scalarNode('destination')->defaultNull()->end()
+                            ->scalarNode('routing_key')->defaultNull()->end()
+                            ->booleanNode('nowait')->defaultFalse()->end()
+                            ->booleanNode('destination_is_exchange')->defaultFalse()->end()
+                            ->variableNode('arguments')->defaultNull()->end()
+                            ->scalarNode('class')->defaultValue('%old_sound_rabbit_mq.binding.class%')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -106,11 +106,12 @@ class OldSoundRabbitMqExtension extends Extension
             ksort($binding);
             $definition = new Definition($binding['class']);
             $definition->addTag('old_sound_rabbit_mq.binding');
-            $definition->addMethodCall('setExchange', array($binding['exchange']));
+            $definition->addMethodCall('setArguments', array($binding['arguments']));
             $definition->addMethodCall('setDestination', array($binding['destination']));
-            $definition->addMethodCall('setRoutingKey', array($binding['routing_key']));
-            $definition->addMethodCall('isNowait', array($binding['nowait']));
             $definition->addMethodCall('setDestinationIsExchange', array($binding['destination_is_exchange']));
+            $definition->addMethodCall('setExchange', array($binding['exchange']));
+            $definition->addMethodCall('isNowait', array($binding['nowait']));
+            $definition->addMethodCall('setRoutingKey', array($binding['routing_key']));
             $this->injectConnection($definition, $binding['connection']);
             $key = md5(json_encode($binding));
             if ($this->collectorEnabled) {

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -118,7 +118,7 @@ class OldSoundRabbitMqExtension extends Extension
                 // in the context of a binding, I don't thing logged channels are needed?
                 $this->injectLoggedChannel($definition, $key, $binding['connection']);
             }
-            $this->container->setDefinition(sprintf('old_sound_rabbit_mq.%s_binding', $key), $definition);
+            $this->container->setDefinition(sprintf('old_sound_rabbit_mq.binding.%s', $key), $definition);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -522,6 +522,21 @@ Be aware that queues providers are responsible for the proper calls to `setDeque
 (not `ConsumerInterface`). In case service providing queues implements `DequeuerAwareInterface`, a call to
 `setDequeuer` is added to the definition of the service with a `DequeuerInterface` currently being a `MultipleConsumer`.
 
+### Arbitrary Bindings ###
+
+You may find that your application has a complex workflow and you you need to have arbitrary binding. Arbitrary
+binding scenarios might include exchange to exchange bindings via `destination_is_exchange` property.
+
+```yaml
+bindings:
+    - {exchange: foo, destination: bar, routing_key: 'baz.*' }
+    - {exchange: foo1, destination: foo, routing_key: 'baz.*' destination_is_exchange: true}
+```
+
+The rabbitmq:setup-fabric command will declare exchanges and queues as defined in your producer, consumer
+and multi consumer configurations before it creates your arbitrary bindings. However, the rabbitmq:setup-fabric will
+*NOT* declare addition queues and exchanges defined in the bindings. It's up to you to make sure exchanges/queues are declared.
+
 ### Dynamic Consumers ###
 
 Sometimes you have to change the consumer's configuration on the fly.

--- a/RabbitMq/AmqpPartsHolder.php
+++ b/RabbitMq/AmqpPartsHolder.php
@@ -18,6 +18,7 @@ class AmqpPartsHolder
 
 	public function getParts($type)
 	{
-		return $this->parts[(string) $type];
+        $type = (string) $type;
+		return isset($this->parts[$type]) ? $this->parts[$type] : array();
 	}
 }

--- a/RabbitMq/Binding.php
+++ b/RabbitMq/Binding.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: brandon
+ * Date: 6/24/15
+ * Time: 3:49 PM
+ */
+
+namespace OldSound\RabbitMqBundle\RabbitMq;
+
+
+class Binding extends BaseAmqp
+{
+    /**
+     * @var string
+     */
+    protected $exchange;
+
+    /**
+     * @var string
+     */
+    protected $destination;
+
+    /**
+     * @var bool
+     */
+    protected $destinationIsExchange = false;
+
+    /**
+     * @var string
+     */
+    protected $routingKey;
+
+    /**
+     * @var bool
+     */
+    protected $nowait = false;
+
+    /**
+     * @var array
+     */
+    protected $arguments;
+
+    /**
+     * @return string
+     */
+    public function getExchange()
+    {
+        return $this->exchange;
+    }
+
+    /**
+     * @param string $exchange
+     */
+    public function setExchange($exchange)
+    {
+        $this->exchange = $exchange;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDestination()
+    {
+        return $this->destination;
+    }
+
+    /**
+     * @param bool $destination
+     */
+    public function setDestination($destination)
+    {
+        $this->destination = $destination;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getDestinationIsExchange()
+    {
+        return $this->destinationIsExchange;
+    }
+
+    /**
+     * @param string $destinationIsExchange
+     */
+    public function setDestinationIsExchange($destinationIsExchange)
+    {
+        $this->destinationIsExchange = $destinationIsExchange;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRoutingKey()
+    {
+        return $this->routingKey;
+    }
+
+    /**
+     * @param string $routingKey
+     */
+    public function setRoutingKey($routingKey)
+    {
+        $this->routingKey = $routingKey;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isNowait()
+    {
+        return $this->nowait;
+    }
+
+    /**
+     * @param boolean $nowait
+     */
+    public function setNowait($nowait)
+    {
+        $this->nowait = $nowait;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @param array $arguments
+     */
+    public function setArguments($arguments)
+    {
+        $this->arguments = $arguments;
+    }
+
+
+    /**
+     * create bindings
+     *
+     * @return void
+     */
+    public function setupFabric()
+    {
+        $method  = ($this->destinationIsExchange) ? 'exchange_bind' : 'queue_bind';
+        $channel = $this->getChannel();
+        call_user_func(
+            array($channel, $method),
+            $this->destination,
+            $this->exchange,
+            $this->routingKey,
+            $this->nowait,
+            $this->arguments
+        );
+    }
+}

--- a/Resources/config/rabbitmq.xml
+++ b/Resources/config/rabbitmq.xml
@@ -7,6 +7,7 @@
         <parameter key="old_sound_rabbit_mq.connection.class">PhpAmqpLib\Connection\AMQPConnection</parameter>
         <parameter key="old_sound_rabbit_mq.lazy.connection.class">PhpAmqpLib\Connection\AMQPLazyConnection</parameter>
         <parameter key="old_sound_rabbit_mq.connection_factory.class">OldSound\RabbitMqBundle\RabbitMq\AMQPConnectionFactory</parameter>
+        <parameter key="old_sound_rabbit_mq.binding.class">OldSound\RabbitMqBundle\RabbitMq\Binding</parameter>
         <parameter key="old_sound_rabbit_mq.producer.class">OldSound\RabbitMqBundle\RabbitMq\Producer</parameter>
         <parameter key="old_sound_rabbit_mq.consumer.class">OldSound\RabbitMqBundle\RabbitMq\Consumer</parameter>
         <parameter key="old_sound_rabbit_mq.multi_consumer.class">OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer</parameter>

--- a/Tests/DependencyInjection/Fixtures/test.yml
+++ b/Tests/DependencyInjection/Fixtures/test.yml
@@ -138,7 +138,9 @@ old_sound_rabbit_mq:
                 type:           direct
             callback: bar.dynamic.callback
             queue_options_provider: bar.dynamic.provider
-            
+    bindings:
+        - {exchange: foo, destination: bar, routing_key: baz}
+        - {exchange: moo, connection: default2, destination: cow, nowait: true, destination_is_exchange: true, arguments: {moo:cow}}
     anon_consumers:
         foo_anon_consumer:
             connection:      foo_connection

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -113,6 +113,44 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
 
+    public function testFooBinding()
+    {
+        $container = $this->getContainer('test.yml');
+        $binding = array(
+            'arguments'                 => null,
+            'class'                     => '%old_sound_rabbit_mq.binding.class%',
+            'connection'                => 'default',
+            'exchange'                  => 'foo',
+            'destination'               => 'bar',
+            'destination_is_exchange'   => false,
+            'nowait'                    => false,
+            'routing_key'               => 'baz',
+        );
+        ksort($binding);
+        $key = md5(json_encode($binding));
+        $name = sprintf('old_sound_rabbit_mq.%s_binding', $key);
+        $this->assertTrue($container->has($name));
+    }
+
+    public function testMooBinding()
+    {
+        $container = $this->getContainer('test.yml');
+        $binding = array(
+            'arguments'                 => array('moo' => 'cow'),
+            'class'                     => '%old_sound_rabbit_mq.binding.class%',
+            'connection'                => 'default2',
+            'exchange'                  => 'moo',
+            'destination'               => 'cow',
+            'destination_is_exchange'   => true,
+            'nowait'                    => true,
+            'routing_key'               => null,
+        );
+        ksort($binding);
+        $key = md5(json_encode($binding));
+        $name = sprintf('old_sound_rabbit_mq.%s_binding', $key);
+        $this->assertTrue($container->has($name));
+    }
+
     public function testFooProducerDefinition()
     {
         $container = $this->getContainer('test.yml');

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -129,7 +129,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         );
         ksort($binding);
         $key = md5(json_encode($binding));
-        $name = sprintf('old_sound_rabbit_mq.%s_binding', $key);
+        $name = sprintf('old_sound_rabbit_mq.binding.%s', $key);
         $this->assertTrue($container->has($name));
         $definition = $container->getDefinition($name);
         $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
@@ -151,7 +151,7 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         );
         ksort($binding);
         $key = md5(json_encode($binding));
-        $name = sprintf('old_sound_rabbit_mq.%s_binding', $key);
+        $name = sprintf('old_sound_rabbit_mq.binding.%s', $key);
         $this->assertTrue($container->has($name));
         $definition = $container->getDefinition($name);
         $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default2');

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -3,6 +3,7 @@
 namespace OldSound\RabbitMqBundle\Tests\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -130,6 +131,9 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $key = md5(json_encode($binding));
         $name = sprintf('old_sound_rabbit_mq.%s_binding', $key);
         $this->assertTrue($container->has($name));
+        $definition = $container->getDefinition($name);
+        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
+        $this->assertBindingMethodCalls($definition, $binding);
     }
 
     public function testMooBinding()
@@ -149,8 +153,54 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $key = md5(json_encode($binding));
         $name = sprintf('old_sound_rabbit_mq.%s_binding', $key);
         $this->assertTrue($container->has($name));
+        $definition = $container->getDefinition($name);
+        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default2');
+        $this->assertBindingMethodCalls($definition, $binding);
     }
 
+    protected function assertBindingMethodCalls(Definition $definition, $binding)
+    {
+        $this->assertEquals(array(
+            array(
+                'setArguments',
+                array(
+                    $binding['arguments']
+                )
+            ),
+            array(
+                'setDestination',
+                array(
+                    $binding['destination']
+                )
+            ),
+            array(
+                'setDestinationIsExchange',
+                array(
+                    $binding['destination_is_exchange']
+                )
+            ),
+            array(
+                'setExchange',
+                array(
+                    $binding['exchange']
+                )
+            ),
+            array(
+                'isNowait',
+                array(
+                    $binding['nowait']
+                )
+            ),
+            array(
+                'setRoutingKey',
+                array(
+                    $binding['routing_key']
+                )
+            ),
+        ),
+            $definition->getMethodCalls()
+        );
+    }
     public function testFooProducerDefinition()
     {
         $container = $this->getContainer('test.yml');

--- a/Tests/RabbitMq/BindingTest.php
+++ b/Tests/RabbitMq/BindingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
+
+
+use OldSound\RabbitMqBundle\RabbitMq\Binding;
+
+class BindingTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected function getBinding($amqpConnection, $amqpChannel)
+    {
+        return new Binding($amqpConnection, $amqpChannel);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function prepareAMQPConnection()
+    {
+        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    protected function prepareAMQPChannel()
+    {
+        return $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testQueueBind()
+    {
+        $ch = $this->prepareAMQPChannel();
+        $con = $this->prepareAMQPConnection();
+
+        $source = 'example_source';
+        $destination = 'example_destination';
+        $key = 'example_key';
+        $ch->expects($this->once())
+            ->method('queue_bind')
+            ->will($this->returnCallback(function ($d, $s, $k, $n, $a) use ($destination, $source, $key) {
+                \PHPUnit_Framework_Assert::assertSame($destination, $d);
+                \PHPUnit_Framework_Assert::assertSame($source, $s);
+                \PHPUnit_Framework_Assert::assertSame($key, $k);
+                \PHPUnit_Framework_Assert::assertFalse($n);
+                \PHPUnit_Framework_Assert::assertNull($a);
+            }));
+
+        $binding = $this->getBinding($con, $ch);
+        $binding->setExchange($source);
+        $binding->setDestination($destination);
+        $binding->setRoutingKey($key);
+        $binding->setupFabric();
+    }
+
+    public function testExhangeBind()
+    {
+        $ch = $this->prepareAMQPChannel();
+        $con = $this->prepareAMQPConnection();
+
+        $source = 'example_source';
+        $destination = 'example_destination';
+        $key = 'example_key';
+        $ch->expects($this->once())
+            ->method('exchange_bind')
+            ->will($this->returnCallback(function ($d, $s, $k, $n, $a) use ($destination, $source, $key) {
+                \PHPUnit_Framework_Assert::assertSame($destination, $d);
+                \PHPUnit_Framework_Assert::assertSame($source, $s);
+                \PHPUnit_Framework_Assert::assertSame($key, $k);
+                \PHPUnit_Framework_Assert::assertFalse($n);
+                \PHPUnit_Framework_Assert::assertNull($a);
+            }));
+
+        $binding = $this->getBinding($con, $ch);
+        $binding->setExchange($source);
+        $binding->setDestination($destination);
+        $binding->setRoutingKey($key);
+        $binding->setDestinationIsExchange(true);
+        $binding->setupFabric();
+    }
+}


### PR DESCRIPTION

You may find that your application has a complex workflow and you you need to have arbitrary binding. Arbitrary binding scenarios might include exchange to exchange bindings via `destination_is_exchange` property.

```yaml
bindings:
    - {exchange: foo, destination: bar, routing_key: 'baz.*' }
    - {exchange: foo1, destination: foo, routing_key: 'baz.*' destination_is_exchange: true}
```

The rabbitmq:setup-fabric command will declare exchanges and queues as defined in your producer, consumer and multi consumer configurations before it creates your arbitrary bindings. However, the rabbitmq:setup-fabric will *NOT* declare addition queues and exchanges defined in the bindings. It's up to you to make sure exchanges/queues are declared.
