### PR TITLE
Lazy services

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -363,6 +363,7 @@ class OldSoundRabbitMqExtension extends Extension
     {
         foreach ($this->config['rpc_clients'] as $key => $client) {
             $definition = new Definition('%old_sound_rabbit_mq.rpc_client.class%');
+            $definition->setLazy(true);
             $definition
                 ->addTag('old_sound_rabbit_mq.rpc_client')
                 ->addMethodCall('initClient', array($client['expect_serialized_response']));


### PR DESCRIPTION
Just asking…

Cf http://symfony.com/doc/current/components/dependency_injection/lazy_services.html and https://github.com/php-amqplib/RabbitMqBundle/pull/217, we need to had some parameters on config, use it in the $definition->setLazy and that's ok?

Thanks.