### PR TITLE
Allow setting headers on publishing message

### DIFF
--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -4,6 +4,7 @@ namespace OldSound\RabbitMqBundle\RabbitMq;
 
 use OldSound\RabbitMqBundle\RabbitMq\BaseAmqp;
 use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Wire\AMQPTable;
 
 /**
  * Producer, that publishes AMQP Messages
@@ -38,14 +39,19 @@ class Producer extends BaseAmqp implements ProducerInterface
      * @param string $msgBody
      * @param string $routingKey
      * @param array $additionalProperties
+     * @param array $headers
      */
-    public function publish($msgBody, $routingKey = '', $additionalProperties = array())
+    public function publish($msgBody, $routingKey = '', $additionalProperties = array(), array $headers = null)
     {
         if ($this->autoSetupFabric) {
             $this->setupFabric();
         }
 
         $msg = new AMQPMessage((string) $msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
+
+        $headersTable = new AMQPTable($headers);
+        $msg->set('application_headers', $headersTable);
+
         $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string) $routingKey);
     }
 }

--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -49,8 +49,10 @@ class Producer extends BaseAmqp implements ProducerInterface
 
         $msg = new AMQPMessage((string) $msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
 
-        $headersTable = new AMQPTable($headers);
-        $msg->set('application_headers', $headersTable);
+        if(!empty($headers)){
+            $headersTable = new AMQPTable($headers);
+            $msg->set('application_headers', $headersTable);
+        }
 
         $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string) $routingKey);
     }


### PR DESCRIPTION
This will enable setting headers when publishing message.
For example it's going to be possible to send delayed message with setting x-delay header (you need x-delayed-message plugin for RabbitMq)