### PR TITLE
When listening for signals consumer never exits on signal

### DIFF
--- a/Command/BaseConsumerCommand.php
+++ b/Command/BaseConsumerCommand.php
@@ -27,9 +27,8 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
             try {
                 $this->consumer->stopConsuming();
             } catch (AMQPTimeoutException $e) {}
-        } else {
-            exit();
         }
+        exit();
     }
 
     public function restartConsumer()


### PR DESCRIPTION
When listening for signals (ie not using -w) the current command will finish processing the current message, unsubscribe for receiving new messages and then sit and wait for the next message to arrive while no longer responding to signals. When in this state it requires a SIGKILL to terminate.

This change will exit the consumer correctly once the shutdown processing is complete.