### PR TITLE
Make processMessage method abstract

### DIFF
--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -45,10 +45,12 @@ abstract class BaseConsumer extends BaseAmqp implements DequeuerInterface
         $this->getChannel()->basic_consume($this->queueOptions['name'], $this->getConsumerTag(), false, false, false, false, array($this, 'processMessage'));
     }
 
-    public function processMessage(AMQPMessage $msg)
-    {
-        //To be implemented by descendant classes
-    }
+    /**
+     * Process an AMQP Message.
+     *
+     * @param AMQPMessage $msg
+     */
+    abstract public function processMessage(AMQPMessage $msg);
 
     protected function maybeStopConsumer()
     {


### PR DESCRIPTION
Hello,
I noticed that the `processMessage` in the abstract class `BaseConsumer` does not have any implementation, it will be good to make the method abstract as the class itself is abstract.
Regards,
