### PR TITLE
added option to use SocketConnection instead of StreamConnection

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('lazy')->defaultFalse()->end()
                             ->scalarNode('connection_timeout')->defaultValue(3)->end()
                             ->scalarNode('read_write_timeout')->defaultValue(3)->end()
+                            ->booleanNode('use_socket')->defaultValue(false)->end()
                             ->arrayNode('ssl_context')
                                 ->useAttributeAsKey('key')
                                 ->canBeUnset()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -71,10 +71,11 @@ class OldSoundRabbitMqExtension extends Extension
     protected function loadConnections()
     {
         foreach ($this->config['connections'] as $key => $connection) {
+            $connectionSuffix = $connection['use_socket'] ? 'socket_connection.class' : 'connection.class';
             $classParam =
                 $connection['lazy']
-                    ? '%old_sound_rabbit_mq.lazy.connection.class%'
-                    : '%old_sound_rabbit_mq.connection.class%';
+                    ? '%old_sound_rabbit_mq.lazy.'.$connectionSuffix.'%'
+                    : '%old_sound_rabbit_mq.'.$connectionSuffix.'%';
 
             $definition = new Definition('%old_sound_rabbit_mq.connection_factory.class%', array(
                 $classParam, $connection,

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ old_sound_rabbit_mq:
 
             # requires php-amqplib v2.4.1+
             heartbeat: 0
+
+            #requires php_sockets.dll
+            use_socket: true # default false
     producers:
         upload_picture:
             connection:       default

--- a/Resources/config/rabbitmq.xml
+++ b/Resources/config/rabbitmq.xml
@@ -5,7 +5,9 @@
 
     <parameters>
         <parameter key="old_sound_rabbit_mq.connection.class">PhpAmqpLib\Connection\AMQPConnection</parameter>
+        <parameter key="old_sound_rabbit_mq.socket_connection.class">PhpAmqpLib\Connection\AMQPSocketConnection</parameter>
         <parameter key="old_sound_rabbit_mq.lazy.connection.class">PhpAmqpLib\Connection\AMQPLazyConnection</parameter>
+        <parameter key="old_sound_rabbit_mq.lazy.socket_connection.class">PhpAmqpLib\Connection\AMQPLazyConnection</parameter>
         <parameter key="old_sound_rabbit_mq.connection_factory.class">OldSound\RabbitMqBundle\RabbitMq\AMQPConnectionFactory</parameter>
         <parameter key="old_sound_rabbit_mq.binding.class">OldSound\RabbitMqBundle\RabbitMq\Binding</parameter>
         <parameter key="old_sound_rabbit_mq.producer.class">OldSound\RabbitMqBundle\RabbitMq\Producer</parameter>

--- a/Resources/config/rabbitmq.xml
+++ b/Resources/config/rabbitmq.xml
@@ -7,7 +7,7 @@
         <parameter key="old_sound_rabbit_mq.connection.class">PhpAmqpLib\Connection\AMQPConnection</parameter>
         <parameter key="old_sound_rabbit_mq.socket_connection.class">PhpAmqpLib\Connection\AMQPSocketConnection</parameter>
         <parameter key="old_sound_rabbit_mq.lazy.connection.class">PhpAmqpLib\Connection\AMQPLazyConnection</parameter>
-        <parameter key="old_sound_rabbit_mq.lazy.socket_connection.class">PhpAmqpLib\Connection\AMQPLazyConnection</parameter>
+        <parameter key="old_sound_rabbit_mq.lazy.socket_connection.class">PhpAmqpLib\Connection\AMQPLazySocketConnection</parameter>
         <parameter key="old_sound_rabbit_mq.connection_factory.class">OldSound\RabbitMqBundle\RabbitMq\AMQPConnectionFactory</parameter>
         <parameter key="old_sound_rabbit_mq.binding.class">OldSound\RabbitMqBundle\RabbitMq\Binding</parameter>
         <parameter key="old_sound_rabbit_mq.producer.class">OldSound\RabbitMqBundle\RabbitMq\Producer</parameter>

--- a/Tests/DependencyInjection/Fixtures/test.yml
+++ b/Tests/DependencyInjection/Fixtures/test.yml
@@ -27,6 +27,24 @@ old_sound_rabbit_mq:
             vhost:    /lazy
             lazy:     true
 
+        socket_connection:
+            host:       bar_host
+            port:       789
+            user:       socket_user
+            password:   socket_password
+            vhost:      /socket
+            lazy:       false
+            use_socket: true
+
+        lazy_socket:
+            host:       joe_host
+            port:       987
+            user:       lazy_socket_user
+            password:   lazy_socket_password
+            vhost:      /lazy_socket
+            lazy:       true
+            use_socket: true
+
         default:
 
     producers:

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -31,8 +31,9 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             'connection_timeout' => 3,
             'read_write_timeout' => 3,
             'ssl_context' => array(),
-            'keepalive' => null,
+            'keepalive' => false,
             'heartbeat' => 0,
+            'use_socket' => false
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
@@ -58,8 +59,9 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             'ssl_context' => array(
                 'verify_peer' => false,
             ),
-            'keepalive' => null,
+            'keepalive' => false,
             'heartbeat' => 0,
+            'use_socket' => false
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
@@ -83,8 +85,9 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             'connection_timeout' => 3,
             'read_write_timeout' => 3,
             'ssl_context' => array(),
-            'keepalive' => null,
+            'keepalive' => false,
             'heartbeat' => 0,
+            'use_socket' => false
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.lazy.connection.class%', $definition->getClass());
     }
@@ -108,10 +111,29 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
             'connection_timeout' => 3,
             'read_write_timeout' => 3,
             'ssl_context' => array(),
-            'keepalive' => null,
+            'keepalive' => false,
             'heartbeat' => 0,
+            'use_socket' => false
         ), $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
+    }
+
+    public function testSocketConnectionDefinition()
+    {
+        $container = $this->getContainer('test.yml');
+        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.socket_connection'));
+        $definiton = $container->getDefinition('old_sound_rabbit_mq.connection.socket_connection');
+        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.socket_connection'));
+        $this->assertEquals('%old_sound_rabbit_mq.socket_connection.class%', $definiton->getClass());
+    }
+
+    public function testLazySocketConnectionDefinition()
+    {
+        $container = $this->getContainer('test.yml');
+        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.lazy_socket'));
+        $definiton = $container->getDefinition('old_sound_rabbit_mq.connection.lazy_socket');
+        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.lazy_socket'));
+        $this->assertEquals('%old_sound_rabbit_mq.lazy.socket_connection.class%', $definiton->getClass());
     }
 
     public function testFooBinding()


### PR DESCRIPTION
This add a configuration option to use `Socket`* connections instead of `Stream`* connections.

On some applications, this setting can reduce drastically the time spent for a basic message publish :

https://blackfire.io/profiles/compare/4f4e9be6-6522-4228-a084-6d0d2c251607/graph
