### PR TITLE
Configurable producer service alias

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -90,6 +90,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('auto_setup_fabric')->defaultTrue()->end()
                             ->scalarNode('class')->defaultValue('%old_sound_rabbit_mq.producer.class%')->end()
                             ->scalarNode('enable_logger')->defaultFalse()->end()
+                            ->scalarNode('service_alias')->defaultValue(null)->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -152,7 +152,12 @@ class OldSoundRabbitMqExtension extends Extension
                     $this->injectLogger($definition);
                 }
 
-                $this->container->setDefinition(sprintf('old_sound_rabbit_mq.%s_producer', $key), $definition);
+                $producerServiceName = sprintf('old_sound_rabbit_mq.%s_producer', $key);
+
+                $this->container->setDefinition($producerServiceName, $definition);
+                if (null !== $producer['service_alias']) {
+                    $this->container->setAlias($producer['service_alias'], $producerServiceName);
+                }
             }
         } else {
             foreach ($this->config['producers'] as $key => $producer) {

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ old_sound_rabbit_mq:
         upload_picture:
             connection:       default
             exchange_options: {name: 'upload-picture', type: direct}
+            service_alias:    my_app_service # no alias by default
     consumers:
         upload_picture:
             connection:       default

--- a/Tests/DependencyInjection/Fixtures/test.yml
+++ b/Tests/DependencyInjection/Fixtures/test.yml
@@ -62,6 +62,21 @@ old_sound_rabbit_mq:
                 arguments:   null
                 ticket:      null
 
+        foo_producer_aliased:
+            class:           My\Foo\Producer
+            connection:      foo_connection
+            exchange_options:
+                name:        foo_exchange
+                type:        direct
+                passive:     true
+                durable:     false
+                auto_delete: true
+                internal:    true
+                nowait:      true
+                arguments:   null
+                ticket:      null
+            service_alias: foo_producer_alias
+
 
         default_producer:
             exchange_options:

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -264,6 +264,17 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('My\Foo\Producer', $definition->getClass());
     }
 
+    /**
+     * @group alias
+     */
+    public function testAliasedFooProducerDefinition()
+    {
+        $container = $this->getContainer('test.yml');
+
+        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_producer_producer'));
+        $this->assertTrue($container->has('foo_producer_alias'));
+    }
+
     public function testDefaultProducerDefinition()
     {
         $container = $this->getContainer('test.yml');


### PR DESCRIPTION
This PR adds the possibility to define a service alias for producers in the configuration.

Example : 

```yaml
producers:
  clicks:
    connection: default
    exchange_options: {name:"clicks", type: direct}
    service_alias: clicks_producer
```

You can then retrieve the producer from the container by both the standard service name or the specified `clicks_producer` alias.