### PR TITLE
Heartbeat implementation on RabbitMQ consumers.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -137,6 +137,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('connection')->defaultValue('default')->end()
                             ->scalarNode('callback')->isRequired()->end()
                             ->scalarNode('idle_timeout')->end()
+                            ->scalarNode('heartbeat_timeout')->end()
                             ->scalarNode('auto_setup_fabric')->defaultTrue()->end()
                             ->arrayNode('qos_options')
                                 ->canBeUnset()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -193,6 +193,11 @@ class OldSoundRabbitMqExtension extends Extension
                 ));
             }
 
+            if (isset($consumer['heartbeat_timeout']) && $consumer['heartbeat_timeout'] > 0) {
+                $definition->addMethodCall('setHeartbeatTimeout', array($consumer['heartbeat_timeout']));
+                $definition->addMethodCall('setHeartbeatCallback', array(array(new Reference($consumer['callback']), 'heartbeat')));
+            }
+
             if (isset($consumer['idle_timeout'])) {
                 $definition->addMethodCall('setIdleTimeout', array($consumer['idle_timeout']));
             }
@@ -256,6 +261,11 @@ class OldSoundRabbitMqExtension extends Extension
                 ));
             }
 
+            if (isset($consumer['heartbeat_timeout']) && $consumer['heartbeat_timeout'] > 0) {
+                $definition->addMethodCall('setHeartbeatTimeout', array($consumer['heartbeat_timeout']));
+                $definition->addMethodCall('setHeartbeatCallback', array(array(new Reference($consumer['callback']), 'heartbeat')));
+            }
+
             if (isset($consumer['idle_timeout'])) {
                 $definition->addMethodCall('setIdleTimeout', array($consumer['idle_timeout']));
             }
@@ -314,6 +324,11 @@ class OldSoundRabbitMqExtension extends Extension
                 'setQueueOptionsProvider',
                 array(new Reference($consumer['queue_options_provider']))
             );
+            
+            if (isset($consumer['heartbeat_timeout']) && $consumer['heartbeat_timeout'] > 0) {
+                $definition->addMethodCall('setHeartbeatTimeout', array($consumer['heartbeat_timeout']));
+                $definition->addMethodCall('setHeartbeatCallback', array(array(new Reference($consumer['callback']), 'heartbeat')));
+            }
 
             if (isset($consumer['idle_timeout'])) {
                 $definition->addMethodCall('setIdleTimeout', array($consumer['idle_timeout']));

--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -12,13 +12,37 @@ abstract class BaseConsumer extends BaseAmqp implements DequeuerInterface
 
     protected $callback;
 
+    protected $heartbeatCallback;
+
     protected $forceStop = false;
 
     protected $idleTimeout = 0;
 
+    protected $heartbeatTimeout = 0;
+
     public function setCallback($callback)
     {
         $this->callback = $callback;
+    }
+
+    public function setHeartbeatCallback($heartbeatCallback)
+    {
+        $this->heartbeatCallback = $heartbeatCallback;
+    }
+
+    public function getHeartbeatCallback()
+    {
+        return $this->heartbeatCallback;
+    }
+
+    public function setHeartbeatTimeout($heartbeatTimeout)
+    {
+        $this->heartbeatTimeout = $heartbeatTimeout;
+    }
+
+    public function getHeartbeatTimeout()
+    {
+        return $this->heartbeatTimeout;
     }
 
     public function start($msgAmount = 0)

--- a/RabbitMq/HeartbeatAwareConsumerInterface.php
+++ b/RabbitMq/HeartbeatAwareConsumerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\RabbitMq;
+
+interface HeartbeatAwareConsumerInterface
+{
+    /**
+     * @param int $consumeDuration
+     * @return void
+     */
+    public function heartbeat($consumeDuration);
+}


### PR DESCRIPTION
In a project I'm working on we have several problems regarding the persistent trait of RabbitMQ consumers. Specifically, when the queue a consumer is listening on has no messages for a while and the consumer is dependant on a MySQL connection, the next message it receives will raise an exception with the message "MySQL has gone away" since MySQL closes any idle connection that sits idle for longer than `wait_timeout`.

To prevent any dependencies between the RabbitMQ bundle and MySQL I thought about having a `heartbeat` function that consumers _can_ implement to perform some periodic tasks (such as refreshing the MySQL socket).

This enables the use of a `heartbeat_timeout` parameter in the consumer configuration that will periodically call the `heartbeat($consumerDuration)` function on the consumer if it implements the `HeartbeatAwareConsumerInterface`. This is being done by passing the `heartbeatTimeout` value into the `$channel->wait(...)` method and checking if we are in a `idleTimeout` or `heartbeatTimeout` situation. If it's the former the exception thrown by the channel is re-raised, otherwise it be swallowed and the consumer will be notified.
