### PR TITLE
old methods was generating duplicate instance for each consumer/producer

### DIFF
--- a/DependencyInjection/Compiler/InjectEventDispatcherPass.php
+++ b/DependencyInjection/Compiler/InjectEventDispatcherPass.php
@@ -4,6 +4,7 @@ namespace OldSound\RabbitMqBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -23,14 +24,15 @@ class InjectEventDispatcherPass implements CompilerPassInterface
         if (!$container->has(self::EVENT_DISPATCHER_SERVICE_ID)) {
             return;
         }
-        $eventDispatcherDefinition = $container->findDefinition(self::EVENT_DISPATCHER_SERVICE_ID);
         $taggedConsumers = $container->findTaggedServiceIds('old_sound_rabbit_mq.base_amqp');
 
         foreach ($taggedConsumers as $id => $tag) {
             $definition = $container->getDefinition($id);
             $definition->addMethodCall(
                 'setEventDispatcher',
-                [$eventDispatcherDefinition]
+                [
+                    new Reference(self::EVENT_DISPATCHER_SERVICE_ID, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)
+                ]
             );
         }
 


### PR DESCRIPTION
The old methods was generating a lot of duplicate objects (event dispatchers).