### PR TITLE
issue #377

### DIFF
--- a/DependencyInjection/Compiler/RegisterPartsPass.php
+++ b/DependencyInjection/Compiler/RegisterPartsPass.php
@@ -10,6 +10,8 @@ class RegisterPartsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        $services = $container->findTaggedServiceIds('old_sound_rabbit_mq.base_amqp');
+        $container->setParameter('old_sound_rabbit_mq.base_amqp', array_keys($services));
         if (!$container->hasDefinition('old_sound_rabbit_mq.parts_holder')) {
             return;
         }

--- a/OldSoundRabbitMqBundle.php
+++ b/OldSoundRabbitMqBundle.php
@@ -23,10 +23,14 @@ class OldSoundRabbitMqBundle extends Bundle
     public function shutdown()
     {
         parent::shutdown();
-        $partHolder = $this->container->get('old_sound_rabbit_mq.parts_holder');
-        $connections = $partHolder->getParts("old_sound_rabbit_mq.base_amqp");
+        if (!$this->container->hasParameter('old_sound_rabbit_mq.base_amqp')) {
+            return;
+        }
+        $connections = $this->container->getParameter('old_sound_rabbit_mq.base_amqp');
         foreach ($connections as $connection) {
-            $connection->close();
+            if ($this->container->initialized($connection)) {
+                $this->container->get($connection)->close();
+            }
         }
     }
 }


### PR DESCRIPTION
issue #377.
Add parameter contain base_amqp connections. Because when get old_sound_rabbit_mq.parts_holder initialized all connections which added to part holder