### PR TITLE
Ability to restart consumer from within "execute" by throwing exception

### DIFF
--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -90,6 +90,15 @@ class Consumer extends BaseConsumer
                     'return_code' => $processFlag
                 )
             ));
+        } catch (Exception\StopConsumerException $e) {
+            $this->logger->info('Consumer requested restart', array(
+                'amqp' => array(
+                    'queue' => $this->queueOptions['name'],
+                    'message' => $msg,
+                    'stacktrace' => $e->getTraceAsString()
+                )
+            ));
+            $this->stopConsuming();
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage(), array(
                 'amqp' => array(

--- a/RabbitMq/Exception/StopConsumerException.php
+++ b/RabbitMq/Exception/StopConsumerException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\RabbitMq\Exception;
+
+/**
+ * If this exception is thrown in consumer service the message
+ * will not be ack and consumer will stop
+ * if using demonized, ex: supervisor, the consumer will actually restart
+ * Class RestartConsumerException
+ * @package OldSound\RabbitMqBundle\RabbitMq\Exception
+ */
+class StopConsumerException extends \RuntimeException
+{
+
+}


### PR DESCRIPTION
Ability to restart consumer from within "execute" by throwing exception
\OldSound\RabbitMqBundle\RabbitMq\Exception\StopConsumerException

This is useful if in consumer an unrecoverable exception that is expected.

For example: 
Doctrine unique constraint exception, closes the the db connection and the best way to handle this would be to restart the process.
