### PR TITLE
FIX: use php 5.3 array

### DIFF
--- a/DependencyInjection/Compiler/InjectEventDispatcherPass.php
+++ b/DependencyInjection/Compiler/InjectEventDispatcherPass.php
@@ -30,9 +30,9 @@ class InjectEventDispatcherPass implements CompilerPassInterface
             $definition = $container->getDefinition($id);
             $definition->addMethodCall(
                 'setEventDispatcher',
-                [
+                array(
                     new Reference(self::EVENT_DISPATCHER_SERVICE_ID, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)
-                ]
+                )
             );
         }
 


### PR DESCRIPTION
A minor fix for the requirement  PHP >= 5.3