### PR TITLE
Ensure multiple consumer follows same processing logic as normal consumer

### DIFF
--- a/RabbitMq/MultipleConsumer.php
+++ b/RabbitMq/MultipleConsumer.php
@@ -84,9 +84,7 @@ class MultipleConsumer extends Consumer
             throw new QueueNotFoundException();
         }
 
-        $processFlag = call_user_func($this->queues[$queueName]['callback'], $msg);
-
-        $this->handleProcessMessage($msg, $processFlag);
+        $this->processMessageQueueCallback($msg, $queueName, $this->queues[$queueName]['callback']);
     }
 
     public function stopConsuming()


### PR DESCRIPTION
Currently `MultipleConsumer` does not handle exceptions in the same way as the regular `Consumer` since it uses its own `processQueueMessage` instead of `processMessage`, which does not include handlers for exceptions like `StopConsumerException`. 

I think that the `MultipleConsumer` should probably have the same behaviour for these exceptions, so I've placed the relevant code in `processMessageQueueCallback` (I'm open to a better name for this) which is called by `processMessage` in `Consumer` and `processQueueMessage` in `MultipleConsumer`. This way when new functionality is added, both consumers should continue to have the same behaviour. 
 