### PR TITLE
Added support for connection URL encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ old_sound_rabbit_mq:
             # A different (unused) connection defined by an URL. One can omit all parts,
             # except the scheme (amqp:). If both segment in the URL and a key value (see above)
             # are given the value from the URL takes precedence.
+            # See https://www.rabbitmq.com/uri-spec.html on how to encode values.
             url: 'amqp://guest:password@localhost:5672/vhost?lazy=1&connection_timeout=6'
     producers:
         upload_picture:

--- a/RabbitMq/AMQPConnectionFactory.php
+++ b/RabbitMq/AMQPConnectionFactory.php
@@ -74,20 +74,21 @@ class AMQPConnectionFactory
             throw new InvalidConfigurationException('Malformed parameter "url".');
         }
 
+        // See https://www.rabbitmq.com/uri-spec.html
         if (isset($url['host'])) {
-            $parameters['host'] = $url['host'];
+            $parameters['host'] = urldecode($url['host']);
         }
         if (isset($url['port'])) {
-            $parameters['port'] = $url['port'];
+            $parameters['port'] = (int)$url['port'];
         }
         if (isset($url['user'])) {
-            $parameters['user'] = $url['user'];
+            $parameters['user'] = urldecode($url['user']);
         }
         if (isset($url['pass'])) {
-            $parameters['password'] = $url['pass'];
+            $parameters['password'] = urldecode($url['pass']);
         }
         if (isset($url['path'])) {
-            $parameters['vhost'] = $url['path'];
+            $parameters['vhost'] = urldecode(ltrim($url['path'], '/'));
         }
 
         if (isset($url['query'])) {

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -91,7 +91,7 @@ class AMQPConnectionFactoryTest extends \PHPUnit_Framework_TestCase
             321,         // port
             'bar_user',  // user
             'bar_password', // password
-            '/whost',    // vhost
+            'whost',     // vhost
             false,       // insist
             "AMQPLAIN",  // login method
             null,        // login response
@@ -99,8 +99,68 @@ class AMQPConnectionFactoryTest extends \PHPUnit_Framework_TestCase
             6,           // connection timeout
             6,           // read write timeout
             null,        // context
-            true,       // keepalive
+            true,        // keepalive
             0,           // heartbeat
+        ), $instance->constructParams);
+    }
+
+    public function testSetConnectionParametersWithUrlEncoded()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection',
+            array(
+                'url' => 'amqp://user%61:%61pass@ho%61st:10000/v%2fhost?keepalive=1&connection_timeout=6&read_write_timeout=6',
+            )
+        );
+
+        /** @var AMQPConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection', $instance);
+        $this->assertEquals(array(
+            'hoast',     // host
+            10000,       // port
+            'usera',     // user
+            'apass',     // password
+            'v/host',    // vhost
+            false,       // insist
+            "AMQPLAIN",  // login method
+            null,        // login response
+            "en_US",     // locale
+            6,           // connection timeout
+            6,           // read write timeout
+            null,        // context
+            true,        // keepalive
+            0,           // heartbeat
+        ), $instance->constructParams);
+    }
+
+    public function testSetConnectionParametersWithUrlWithoutVhost()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection',
+            array(
+                'url' => 'amqp://user:pass@host:321/?keepalive=1&connection_timeout=6&read_write_timeout=6',
+            )
+        );
+
+        /** @var AMQPConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection', $instance);
+        $this->assertEquals(array(
+            'host',     // host
+            321,        // port
+            'user',     // user
+            'pass',     // password
+            '',         // vhost
+            false,      // insist
+            "AMQPLAIN", // login method
+            null,       // login response
+            "en_US",    // locale
+            6,          // connection timeout
+            6,          // read write timeout
+            null,       // context
+            true,       // keepalive
+            0,          // heartbeat
         ), $instance->constructParams);
     }
 


### PR DESCRIPTION
With the introduction of the URL connection encoding was not taken into consideration.
See https://www.rabbitmq.com/uri-spec.html for more details.

Without this is not possible to connect with a vhost that does not start with '/'
