### PR TITLE
AnonConsumers don't work with lazy connections

### DIFF
--- a/RabbitMq/AnonConsumer.php
+++ b/RabbitMq/AnonConsumer.php
@@ -3,11 +3,11 @@
 namespace OldSound\RabbitMqBundle\RabbitMq;
 
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AbstractConnection;
 
 class AnonConsumer extends Consumer
 {
-    public function __construct(AMQPConnection $conn)
+    public function __construct(AbstractConnection $conn)
     {
         parent::__construct($conn);
 


### PR DESCRIPTION
This is because the `AnonConsumer` constructor expects a connection of type `AMQPConnection`, which has been deprecated in favour of `AbstractConnection`.