### PR TITLE
Do not create channel for lazy socket connection on construct

### DIFF
--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -64,7 +64,7 @@ abstract class BaseAmqp
         $this->conn = $conn;
         $this->ch = $ch;
 
-        if (!($conn instanceof AMQPLazyConnection)) {
+        if ($conn->connectOnConstruct()) {
             $this->getChannel();
         }
 

--- a/Tests/RabbitMq/BaseAmqpTest.php
+++ b/Tests/RabbitMq/BaseAmqpTest.php
@@ -5,19 +5,40 @@ namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 use OldSound\RabbitMqBundle\Event\AMQPEvent;
 use OldSound\RabbitMqBundle\RabbitMq\BaseAmqp;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
-use PhpAmqpLib\Connection\AMQPLazyConnection;
 
 class BaseAmqpTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException \ErrorException
-     */
+
     public function testLazyConnection()
     {
-        $amqpLazyConnection = new AMQPLazyConnection('localhost', 123, 'lazy_user', 'lazy_password');
+        $connection = $this->getMockBuilder('PhpAmqpLib\Connection\AbstractConnection')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $consumer = new Consumer($amqpLazyConnection, null);
-        $consumer->getChannel();
+        $connection
+            ->method('connectOnConstruct')
+            ->willReturn(false);
+        $connection
+            ->expects(static::never())
+            ->method('channel');
+
+        new Consumer($connection, null);
+    }
+
+    public function testNotLazyConnection()
+    {
+        $connection = $this->getMockBuilder('PhpAmqpLib\Connection\AbstractConnection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connection
+            ->method('connectOnConstruct')
+            ->willReturn(true);
+        $connection
+            ->expects(static::once())
+            ->method('channel');
+
+        new Consumer($connection, null);
     }
 
     public function testDispatchEvent()
@@ -26,7 +47,7 @@ class BaseAmqpTest extends \PHPUnit_Framework_TestCase
         $baseAmqpConsumer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\BaseAmqp')
             ->disableOriginalConstructor()
             ->getMock();
-        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
             ->disableOriginalConstructor()
             ->getMock();
         $baseAmqpConsumer->expects($this->atLeastOnce())


### PR DESCRIPTION
Now when using lazy socket connection and class extending BaseAmqp is initiated, channel is created.
Thou when lazy stream connection is used, channel would not be initialized.
This PR fixes this bug.