### PR TITLE
Fix for consumer with empty queue not being able to handle SIGTERM and SIGINT

### DIFF
--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -34,9 +34,15 @@ abstract class BaseConsumer extends BaseAmqp implements DequeuerInterface
         }
     }
 
+    /**
+     * Tell the server you are going to stop consuming.
+     *
+     * It will finish up the last message and not send you any more.
+     */
     public function stopConsuming()
     {
-        $this->getChannel()->basic_cancel($this->getConsumerTag());
+        // This gets stuck and will not exit without the last two parameters set.
+        $this->getChannel()->basic_cancel($this->getConsumerTag(), false, true);
     }
 
     protected function setupConsumer()


### PR DESCRIPTION
Whenever sending a SIGTERM or SIGINT to a consumer it will only be able to shut itself down on a next message. But this might be problematic for queues which are not that active. Previously this has been solved by having an exit statement after `BaseConsumerCommand::stopConsumer()` method (ref: https://github.com/php-amqplib/RabbitMqBundle/commit/4f6a5c86c7dabf5fee3aa7f9e656998ef90fa8cd).

This implementation is done referencing to https://github.com/php-amqplib/php-amqplib/pull/224 and this example [amqp_consumer_signals.php#L179](https://github.com/roihq/php-amqplib/blob/ddb5b0374f34a454cd8f772f9a12f147e8c33e30/demo/amqp_consumer_signals.php#L179)

The only thing that I am concerned is that I think we are no longer waiting for `basic.cancel_ok` signal. Are there any possible scenarios that this could go wrong?

This solution still dispatches "console.terminate" as requested in #372. Doesn't do an exit call like it was previously implemented.

Fix for #352 #178 #260