### PR TITLE
Fix for consumer with empty queue not handling SIGTERM/SIGINT

### DIFF
--- a/RabbitMq/MultipleConsumer.php
+++ b/RabbitMq/MultipleConsumer.php
@@ -102,7 +102,7 @@ class MultipleConsumer extends Consumer
     public function stopConsuming()
     {
         foreach ($this->queues as $name => $options) {
-            $this->getChannel()->basic_cancel($this->getQueueConsumerTag($name));
+            $this->getChannel()->basic_cancel($this->getQueueConsumerTag($name), false, true);
         }
     }
 


### PR DESCRIPTION
This applies the change made in d3fef7fde58424af42d0a6f8e844b7b99fbe5840 to the MultipleConsumer

Refs #352 #178 #260