### PR TITLE
Wrong usage function isRamAlmostOverloaded in Consumer class

### DIFF
--- a/Command/BaseConsumerCommand.php
+++ b/Command/BaseConsumerCommand.php
@@ -43,7 +43,7 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
             ->addArgument('name', InputArgument::REQUIRED, 'Consumer Name')
             ->addOption('messages', 'm', InputOption::VALUE_OPTIONAL, 'Messages to consume', 0)
             ->addOption('route', 'r', InputOption::VALUE_OPTIONAL, 'Routing Key', '')
-            ->addOption('memory-limit', 'l', InputOption::VALUE_OPTIONAL, 'Allowed memory for this process', null)
+            ->addOption('memory-limit', 'l', InputOption::VALUE_OPTIONAL, 'Allowed memory for this process (MB)', null)
             ->addOption('debug', 'd', InputOption::VALUE_NONE, 'Enable Debugging')
             ->addOption('without-signals', 'w', InputOption::VALUE_NONE, 'Disable catching of system signals')
         ;

--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -175,6 +175,6 @@ class Consumer extends BaseConsumer
     {
         $memoryManager = new MemoryConsumptionChecker(new NativeMemoryUsageProvider());
 
-        return $memoryManager->isRamAlmostOverloaded($this->getMemoryLimit(), '5M');
+        return $memoryManager->isRamAlmostOverloaded('5M', $this->getMemoryLimit().'M');
     }
 }


### PR DESCRIPTION
Hello, I found 2 mistakes in isRamAlmostOverloaded function

1. First parameter must be $allowedConsumptionUntil, but used $maxConsumptionAllowed
2. getMemoryLimit must be in MB (accouding readme file)

Thanks.