### PR TITLE
Made AMQP Factory aware of the connection alias and detailed exceptio…

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -79,7 +79,7 @@ class OldSoundRabbitMqExtension extends Extension
                     : '%old_sound_rabbit_mq.'.$connectionSuffix.'%';
 
             $definition = new Definition('%old_sound_rabbit_mq.connection_factory.class%', array(
-                $classParam, $connection,
+                $classParam, $connection, $key
             ));
             $definition->setPublic(false);
             $factoryName = sprintf('old_sound_rabbit_mq.connection_factory.%s', $key);

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -861,6 +861,22 @@ class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * Test that the factory definition contains the alias argument
+     */
+    public function testConnectionFactoryAlias()
+    {
+        $definition = $this->getContainer('test.yml')
+            ->getDefinition('old_sound_rabbit_mq.connection_factory.foo_connection');
+
+        // arguments: [0 => $class, 1 => $parameters, $connectionAlias]
+        $this->assertEquals(
+            $definition->getArgument(2),
+            'foo_connection',
+            "Factory definition does not contain alias argument"
+        );
+    }
+
     private function getContainer($file, $debug = false)
     {
         $container = new ContainerBuilder(new ParameterBag(array('kernel.debug' => $debug)));

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -208,4 +208,23 @@ class AMQPConnectionFactoryTest extends \PHPUnit_Framework_TestCase
             0,           // heartbeat
         ), $instance->constructParams);
     }
+
+    /**
+     * Test that failed AMQPConnection throws an error with reference for the
+     * collection alias name
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Could not create connection for my_connection: Dummy exception
+     */
+    public function testConnectionAliasAwareness()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\FailedAMQPConnection',
+            array(
+                'host' => 'foo',
+            ),
+            'my_connection'
+        );
+        $factory->createConnection();
+    }
 }

--- a/Tests/RabbitMq/Fixtures/FailedAMQPConnection.php
+++ b/Tests/RabbitMq/Fixtures/FailedAMQPConnection.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures;
+
+class FailedAMQPConnection
+{
+    public $constructParams;
+
+    public function __construct()
+    {
+        throw new \RuntimeException("Dummy exception");
+    }
+}


### PR DESCRIPTION
Related to issues: https://github.com/php-amqplib/RabbitMqBundle/issues/438

It is not that elegant in context of making the factory aware of something that does not concern it, also, decorating the exception, but it is an useful tool that "patches" the current design.