### PR TITLE
Remove support for Symfony <2.7 & allow to install with Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,50 @@
 language: php
 
-matrix:
-  allow_failures:
-    - php: hhvm
-      env: SYMFONY_VERSION=2.3.*
-    - php: hhvm
-      env: SYMFONY_VERSION=2.7.*
-    - php: hhvm
-      env: SYMFONY_VERSION=2.8.*
+sudo: false
 
+php:
+  - 7.1
+  - 7.0
+  - 5.6
+  - 5.6
+  - nightly
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  fast_finish: true
   include:
     - php: 5.3
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.3
       env: SYMFONY_VERSION=2.7.*
     - php: 5.3
       env: SYMFONY_VERSION=2.8.*
 
-    - php: 5.4
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.4
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.4
-      env: SYMFONY_VERSION=2.8.*
+    - php: 5.6
+      env: COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
 
-    - php: 5.5
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.5
-      env: SYMFONY_VERSION=3.0.*
-
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-
-    - php: 7.0
-      env: SYMFONY_VERSION=2.3.*
     - php: 7.0
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0
       env: SYMFONY_VERSION=2.8.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
+
+  allow_failures:
+    - php: nightly
 
 env:
   global:
     - SYMFONY_VERSION=""
 
 before_install:
+  - phpenv config-rm xdebug.ini || echo "xdebug not available";
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle "$SYMFONY_VERSION"; fi
+  - if [ "$COMPOSER_FLAGS" != "" ]; then composer update --prefer-dist --no-interaction --no-scripts $COMPOSER_FLAGS; fi;
 
 install:
-  - composer install --prefer-source
+  - composer install --prefer-dist
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -8,20 +8,20 @@
         "name" : "Alvaro Videla"
     }],
     "require": {
-        "php":                          ">=5.3.0",
+        "php":                          "^5.3.9|^7.0",
 
-        "symfony/dependency-injection": "~2.3 || ~3.0",
-        "symfony/event-dispatcher":     "~2.3 || ~3.0",
-        "symfony/config":               "~2.3 || ~3.0",
-        "symfony/yaml":                 "~2.3 || ~3.0",
-        "symfony/console":              "~2.3 || ~3.0",
-        "php-amqplib/php-amqplib":      "~2.6",
-        "psr/log": "~1.0"
+        "symfony/dependency-injection": "^2.7|^3.0|^4.0",
+        "symfony/event-dispatcher":     "^2.7|^3.0|^4.0",
+        "symfony/config":               "^2.7|^3.0|^4.0",
+        "symfony/yaml":                 "^2.7|^3.0|^4.0",
+        "symfony/console":              "^2.7|^3.0|^4.0",
+        "php-amqplib/php-amqplib":      "^2.6",
+        "psr/log":                      "^1.0"
     },
     "require-dev": {
-        "symfony/serializer":           "~2.3 || ~3.0",
-        "symfony/debug":                "~2.3 || ~3.0",
-        "phpunit/phpunit":              "~4.8 || ~5.0"
+        "symfony/serializer":           "^2.7|^3.0|^4.0",
+        "symfony/debug":                "^2.7|^3.0|^4.0",
+        "phpunit/phpunit":              "^4.8|^5.0"
     },
     "replace": {
         "oldsound/rabbitmq-bundle": "self.version"


### PR DESCRIPTION
Minimal version required for PHP is 5.3.9 to match Symfony 2.7 requirements. Additionally this will allow to install bundle on PHP 7.