### PR TITLE
[Feature ] Tagged old_sound_rabbitmq connections

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -97,6 +97,7 @@ class OldSoundRabbitMqExtension extends Extension
                 $definition->setFactoryService($factoryName);
                 $definition->setFactoryMethod('createConnection');
             }
+            $definition->addTag('old_sound_rabbit_mq.connection');
 
             $this->container->setDefinition(sprintf('old_sound_rabbit_mq.connection.%s', $key), $definition);
         }


### PR DESCRIPTION
Tagged old sound connections in order to have the capability for making a small container for these connections.