### PR TITLE
Fixing xml configuration for routing-keys

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -402,6 +402,7 @@ class Configuration implements ConfigurationInterface
     protected function addQueueNodeConfiguration(ArrayNodeDefinition $node)
     {
         $node
+            ->fixXmlConfig('routing_key')
             ->children()
                 ->scalarNode('name')->end()
                 ->booleanNode('passive')->defaultFalse()->end()


### PR DESCRIPTION
This is a follow-up to https://github.com/php-amqplib/RabbitMqBundle/pull/210.

Currently setting multiple routing keys using xml configuration:

```xml
<queue-options>
    <name>test-queue</name>
    <routing-keys>
        <routing-key>foo</routing-key>
        <routing-key>bar</routing-key>
    </routing-keys>
</queue-options>
```

Ends with:

```
[Symfony\Component\Config\Definition\Exception\InvalidTypeException]                                                                                   
  Invalid type for path "old_sound_rabbit_mq.consumers.test_consumer.queue_options.routing_keys.routing_key". Expected scalar, but got array. 
```

But works for single routing key, that is confusing:

```xml
<queue-options>
    <name>test-queue</name>
    <routing-keys>
        <routing-key>foo</routing-key>
    </routing-keys>
</queue-options>
```

There is a solution mentioned in https://github.com/php-amqplib/RabbitMqBundle/issues/197

```xml
<queue-options>
    <name>test-queue</name>
    <routing-keys>
        foo
    </routing-keys>
    <routing-keys>
        bar
    </routing-keys>
</queue-options>
```

But it would be nice to use the same valid way that https://github.com/php-amqplib/RabbitMqBundle/pull/210 introduced for routing keys.

After merge, configuration like this:

```xml
<queue-options>
    <name>test-queue</name>
    <routing-key>foo</routing-key>
    <routing-key>bar</routing-key>
</queue-options>
```

Is valid and works as expected.