### PR TITLE
Ignore dynamic consumers when creating fabric

### DIFF
--- a/Command/SetupFabricCommand.php
+++ b/Command/SetupFabricCommand.php
@@ -2,6 +2,7 @@
 
 namespace OldSound\RabbitMqBundle\Command;
 
+use OldSound\RabbitMqBundle\RabbitMq\DynamicConsumer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,6 +30,9 @@ class SetupFabricCommand extends BaseRabbitMqCommand
 
         foreach (array('base_amqp', 'binding') as $key) {
             foreach ($partsHolder->getParts('old_sound_rabbit_mq.' . $key) as $baseAmqp) {
+                if ($baseAmqp instanceof DynamicConsumer) {
+                    continue;
+                }
                 $baseAmqp->setupFabric();
             }
         }


### PR DESCRIPTION
Fix for [https://github.com/php-amqplib/RabbitMqBundle/issues/462](https://github.com/php-amqplib/RabbitMqBundle/issues/462)

Because dynamic consumers are context dependent it is not possible to setup fabric for this. However it might be necessary to setup rest of the fabric using this command. This fix just skips over the dynamic consumers when setting up the fabric.