### PR TITLE
BatchConsumer loop after SIGTERM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,14 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
 
   include:
-    - php: 5.3
+    - dist: precise
+      php: 5.3
       env: SYMFONY_VERSION=2.3.*
-    - php: 5.3
+    - dist: precise
+      php: 5.3
       env: SYMFONY_VERSION=2.7.*
-    - php: 5.3
+    - dist: precise
+      php: 5.3
       env: SYMFONY_VERSION=2.8.*
 
     - php: 5.4

--- a/RabbitMq/BatchConsumer.php
+++ b/RabbitMq/BatchConsumer.php
@@ -10,11 +10,6 @@ use PhpAmqpLib\Message\AMQPMessage;
 final class BatchConsumer extends BaseAmqp implements DequeuerInterface
 {
     /**
-     * @var int
-     */
-    private $consumed = 0;
-
-    /**
      * @var \Closure|callable
      */
     private $callback;
@@ -75,43 +70,32 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
     {
         $this->setupConsumer();
 
-        $isConsuming = false;
-        $timeoutWanted = $this->getTimeoutWait();
         while (count($this->getChannel()->callbacks)) {
+            if ($this->isCompleteBatch()) {
+                $this->batchConsume();
+            }
+
             $this->maybeStopConsumer();
-            if (!$this->forceStop) {
-                try {
-                    $this->getChannel()->wait(null, false, $timeoutWanted);
-                    $isConsuming = true;
-                } catch (AMQPTimeoutException $e) {
+
+            $timeout = $this->isEmptyBatch() ? $this->getIdleTimeout() : $this->getTimeoutWait();
+
+            try {
+                $this->getChannel()->wait(null, false, $timeout);
+            } catch (AMQPTimeoutException $e) {
+                if (!$this->isEmptyBatch()) {
                     $this->batchConsume();
-                    if ($isConsuming) {
-                        $isConsuming = false;
-                    } elseif (null !== $this->getIdleTimeoutExitCode()) {
-                        return $this->getIdleTimeoutExitCode();
-                    } else {
-                        throw $e;
-                    }
+                } elseif (null !== $this->getIdleTimeoutExitCode()) {
+                    return $this->getIdleTimeoutExitCode();
+                } else {
+                    throw $e;
                 }
-            } else {
-                $this->batchConsume();
             }
-
-            if ($this->isCompleteBatch($isConsuming)) {
-                $this->batchConsume();
-            }
-
-            $timeoutWanted = $isConsuming ? $this->getTimeoutWait() : $this->getIdleTimeout();
         }
     }
 
-    public function batchConsume()
+    private function batchConsume()
     {
-        if ($this->batchCounter === 0) {
-            return;
-        }
-
-        try  {
+        try {
             $processFlags = call_user_func($this->callback, $this->messages);
             $this->handleProcessMessages($processFlags);
             $this->logger->debug('Queue message processed', array(
@@ -129,6 +113,7 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
                     'stacktrace' => $e->getTraceAsString()
                 )
             ));
+            $this->resetBatch();
             $this->stopConsuming();
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage(), array(
@@ -166,9 +151,6 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
         foreach ($processFlags as $deliveryTag => $processFlag) {
             $this->handleProcessFlag($deliveryTag, $processFlag);
         }
-
-        $this->consumed++;
-        $this->maybeStopConsumer();
     }
 
     /**
@@ -177,7 +159,7 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
      *
      * @return  void
      */
-    private function handleProcessFlag ($deliveryTag, $processFlag)
+    private function handleProcessFlag($deliveryTag, $processFlag)
     {
         if ($processFlag === ConsumerInterface::MSG_REJECT_REQUEUE || false === $processFlag) {
             // Reject and requeue message to RabbitMQ
@@ -195,13 +177,19 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
     }
 
     /**
-     * @param   bool    $isConsuming
-     *
      * @return  bool
      */
-    protected function isCompleteBatch($isConsuming)
+    protected function isCompleteBatch()
     {
-        return $isConsuming && $this->batchCounter === $this->prefetchCount;
+        return $this->batchCounter === $this->prefetchCount;
+    }
+
+    /**
+     * @return  bool
+     */
+    protected function isEmptyBatch()
+    {
+        return $this->batchCounter === 0;
     }
 
     /**
@@ -300,7 +288,9 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
      */
     public function stopConsuming()
     {
-        $this->batchConsume();
+        if (!$this->isEmptyBatch()) {
+            $this->batchConsume();
+        }
 
         $this->getChannel()->basic_cancel($this->getConsumerTag());
     }

--- a/RabbitMq/BatchConsumer.php
+++ b/RabbitMq/BatchConsumer.php
@@ -85,10 +85,6 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
         $this->addMessage($msg);
 
         $this->maybeStopConsumer();
-
-        if (null !== $this->getMemoryLimit() && $this->isRamAlmostOverloaded()) {
-            $this->stopConsuming();
-        }
     }
 
     public function consume()
@@ -189,10 +185,6 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
 
         $this->consumed++;
         $this->maybeStopConsumer();
-
-        if (null !== $this->getMemoryLimit() && $this->isRamAlmostOverloaded()) {
-            $this->stopConsuming();
-        }
     }
 
     /**
@@ -388,6 +380,10 @@ final class BatchConsumer extends BaseAmqp implements DequeuerInterface
         }
 
         if ($this->forceStop) {
+            $this->stopConsuming();
+        }
+
+        if (null !== $this->getMemoryLimit() && $this->isRamAlmostOverloaded()) {
             $this->stopConsuming();
         }
     }


### PR DESCRIPTION
This pull request solves a bug I discovered on the BatchConsumer. 
When sent a SIGTERM or SIGINT if at least one message of the batch was loaded it would start looping until reaching the maximum function nesting and throwing a fatal error. 

loop chain is:
stopConsumer -> batchConsume -> handleProcessMessages -> maybeStopConsumer -> stopConsumer

this also causes the same batch of messages to be processed multiple times. 

