### PR TITLE
Fixed config:dump-reference, fixed PHPUnit deprecated warning (#477)

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -40,7 +40,7 @@ class OldSoundRabbitMqExtension extends Extension
         $loader = new XmlFileLoader($this->container, new FileLocator(array(__DIR__ . '/../Resources/config')));
         $loader->load('rabbitmq.xml');
 
-        $configuration = new Configuration($this->getAlias());
+        $configuration = $this->getConfiguration($configs, $container);
         $this->config = $this->processConfiguration($configuration, $configs);
 
         $this->collectorEnabled = $this->config['enable_collector'];
@@ -67,6 +67,11 @@ class OldSoundRabbitMqExtension extends Extension
         } else {
             $this->container->removeDefinition('old_sound_rabbit_mq.data_collector');
         }
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration($this->getAlias());
     }
 
     protected function loadConnections()

--- a/Tests/RabbitMq/RpcClientTest.php
+++ b/Tests/RabbitMq/RpcClientTest.php
@@ -3,6 +3,7 @@
 namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 
 use OldSound\RabbitMqBundle\RabbitMq\RpcClient;
+use PhpAmqpLib\Message\AMQPMessage;
 
 class RpcClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,8 +14,14 @@ class RpcClientTest extends \PHPUnit_Framework_TestCase
             ->setMethods(array('sendReply', 'maybeStopConsumer'))
             ->disableOriginalConstructor()
             ->getMock();
-        $message = $this->getMockBuilder('\PhpAmqpLib\Message\AMQPMessage')->setMethods(array('get'))->setConstructorArgs(array('message'))->getMock();
-        $serializer = $this->getMockBuilder('\Symfony\Component\Serializer\SerializerInterface')->setMethods(array('serialize', 'deserialize'))->getMock();
+        /** @var AMQPMessage $message */
+        $message = $this->getMockBuilder('\PhpAmqpLib\Message\AMQPMessage')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array('message'))
+            ->getMock();
+        $serializer = $this->getMockBuilder('\Symfony\Component\Serializer\SerializerInterface')
+            ->setMethods(array('serialize', 'deserialize'))
+            ->getMock();
         $serializer->expects($this->once())->method('deserialize')->with('message', 'json', null);
         $client->initClient(true);
         $client->setUnserializer(function($data) use ($serializer) {
@@ -22,7 +29,7 @@ class RpcClientTest extends \PHPUnit_Framework_TestCase
         });
         $client->processMessage($message);
     }
-    
+
     public function testProcessMessageWithNotifyMethod()
     {
         /** @var RpcClient $client */
@@ -31,7 +38,11 @@ class RpcClientTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $expectedNotify = 'message';
-        $message = $this->getMock('\PhpAmqpLib\Message\AMQPMessage', array('get'), array($expectedNotify));
+        /** @var AMQPMessage $message */
+        $message = $this->getMockBuilder('\PhpAmqpLib\Message\AMQPMessage')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($expectedNotify))
+            ->getMock();
         $notified = false;
         $client->notify(function ($message) use (&$notified) {
             $notified = $message;


### PR DESCRIPTION
It is resolved #477 by adding `getConfiguration()` method to `OldSoundRabbitMqExtension` class.