### PR TITLE
Fix AMQPSocketConnection instantiation by the factory

### DIFF
--- a/RabbitMq/AMQPConnectionFactory.php
+++ b/RabbitMq/AMQPConnectionFactory.php
@@ -4,6 +4,7 @@ namespace OldSound\RabbitMqBundle\RabbitMq;
 
 use OldSound\RabbitMqBundle\Provider\ConnectionParametersProviderInterface;
 use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Connection\AMQPSocketConnection;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class AMQPConnectionFactory
@@ -60,6 +61,25 @@ class AMQPConnectionFactory
      */
     public function createConnection()
     {
+        // AMQPSocketConnection doesn't take same parameters than AMQPStreamConnection
+        if (is_a($this->class, AMQPSocketConnection::class, true)) {
+            return new $this->class(
+                $this->parameters['host'],
+                $this->parameters['port'],
+                $this->parameters['user'],
+                $this->parameters['password'],
+                $this->parameters['vhost'],
+                false,      // insist
+                'AMQPLAIN', // login_method
+                null,       // login_response
+                'en_US',    // locale
+                $this->parameters['read_write_timeout'],
+                $this->parameters['keepalive'],
+                $this->parameters['read_write_timeout'],
+                $this->parameters['heartbeat']
+            );
+        }
+
         return new $this->class(
             $this->parameters['host'],
             $this->parameters['port'],

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -70,6 +70,69 @@ class AMQPConnectionFactoryTest extends \PHPUnit_Framework_TestCase
         ), $instance->constructParams);
     }
 
+    public function testSocketDefaultValues()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection',
+            array()
+        );
+
+        /** @var AMQPConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection', $instance);
+        $this->assertEquals(array(
+            'localhost', // host
+            5672,        // port
+            'guest',     // user
+            'guest',     // password
+            '/',         // vhost
+            false,       // insist
+            "AMQPLAIN",  // login method
+            null,        // login response
+            "en_US",     // locale
+            3,           // read timeout
+            false,       // keepalive
+            3,           // write timeout
+            0,           // heartbeat
+        ), $instance->constructParams);
+    }
+
+    public function testSocketStandardConnectionParameters()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection',
+            array(
+                'host' => 'foo_host',
+                'port' => 123,
+                'user' => 'foo_user',
+                'password' => 'foo_password',
+                'vhost' => '/vhost',
+                'keepalive' => true,
+                'read_write_timeout' => 321,
+                'heartbeat' => 111,
+            )
+        );
+
+        /** @var AMQPConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection', $instance);
+        $this->assertEquals(array(
+            'foo_host',  // host
+            123,         // port
+            'foo_user',  // user
+            'foo_password', // password
+            '/vhost',    // vhost
+            false,       // insist
+            "AMQPLAIN",  // login method
+            null,        // login response
+            "en_US",     // locale
+            321,           // read timeout
+            true,       // keepalive
+            321,           // write timeout
+            111,           // heartbeat
+        ), $instance->constructParams);
+    }
+
     public function testSetConnectionParametersWithUrl()
     {
         $factory = new AMQPConnectionFactory(

--- a/Tests/RabbitMq/Fixtures/AMQPSocketConnection.php
+++ b/Tests/RabbitMq/Fixtures/AMQPSocketConnection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures;
+
+class AMQPSocketConnection extends \PhpAmqpLib\Connection\AMQPSocketConnection
+{
+    public $constructParams;
+
+    public function __construct()
+    {
+        // save params for direct access in tests
+        $this->constructParams = func_get_args();
+    }
+}


### PR DESCRIPTION
`AMQPSocketConnection` and `AMQPStreamConnection` doesn't have the same constructor but the factory ( `AMQPConnectionFactory` ) call them with the same parameters.

https://github.com/php-amqplib/RabbitMqBundle/blob/74b63c0e2807b7b436a6b160849129e2d37cef7b/RabbitMq/AMQPConnectionFactory.php#L63-L78

The 2 constructors:
https://github.com/php-amqplib/php-amqplib/blob/0f90b3d8bc50403458f0eefbcba7d1e2329dd0f6/PhpAmqpLib/Connection/AMQPSocketConnection.php#L33-L36
https://github.com/php-amqplib/php-amqplib/blob/0f90b3d8bc50403458f0eefbcba7d1e2329dd0f6/PhpAmqpLib/Connection/AMQPStreamConnection.php#L18-L22

At this moment, when using `use_socket: true`:
`connection_timeout` is used as `read_timeout`
`read_write_timeout` is used as `keepalive`
`ssl_context` is used as `write_timeout`
`keepalive` is used as `heartbeat`
`heartbeat` is lost (socket construct takes only 13 params, instead 14 for stream)