### PR TITLE
Fix PHPUnit deprecation warning

### DIFF
--- a/Tests/RabbitMq/RpcClientTest.php
+++ b/Tests/RabbitMq/RpcClientTest.php
@@ -31,7 +31,10 @@ class RpcClientTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $expectedNotify = 'message';
-        $message = $this->getMock('\PhpAmqpLib\Message\AMQPMessage', array('get'), array($expectedNotify));
+        $message = $this->getMockBuilder('\PhpAmqpLib\Message\AMQPMessage')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($expectedNotify))
+            ->getMock();
         $notified = false;
         $client->notify(function ($message) use (&$notified) {
             $notified = $message;


### PR DESCRIPTION
Fixes:

```
There was 1 warning:

1) OldSound\RabbitMqBundle\Tests\RabbitMq\RpcClientTest::testProcessMessageWithNotifyMethod
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead
```