### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/Command/BaseCommandTest.php
+++ b/Tests/Command/BaseCommandTest.php
@@ -2,7 +2,9 @@
 
 namespace OldSound\RabbitMqBundle\Tests\Command;
 
-abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseCommandTest extends TestCase
 {
     protected $application;
     protected $definition;

--- a/Tests/Command/ConsumerCommandTest.php
+++ b/Tests/Command/ConsumerCommandTest.php
@@ -3,7 +3,6 @@
 namespace OldSound\RabbitMqBundle\Tests\Command;
 
 use OldSound\RabbitMqBundle\Command\ConsumerCommand;
-
 use Symfony\Component\Console\Input\InputOption;
 
 class ConsumerCommandTest extends BaseCommandTest

--- a/Tests/Command/DynamicConsumerCommandTest.php
+++ b/Tests/Command/DynamicConsumerCommandTest.php
@@ -3,11 +3,11 @@
 namespace OldSound\RabbitMqBundle\Tests\Command;
 
 use OldSound\RabbitMqBundle\Command\DynamicConsumerCommand;
-
 use Symfony\Component\Console\Input\InputOption;
 
-class DynamicConsumerCommandTest extends BaseCommandTest{
-    
+class DynamicConsumerCommandTest extends BaseCommandTest
+{
+
     protected function setUp()
     {
         parent::setUp();
@@ -25,7 +25,7 @@ class DynamicConsumerCommandTest extends BaseCommandTest{
         $this->command = new DynamicConsumerCommand();
         $this->command->setApplication($this->application);
     }
-    
+
     /**
      * testInputsDefinitionCommand
      */
@@ -35,7 +35,7 @@ class DynamicConsumerCommandTest extends BaseCommandTest{
         $definition = $this->command->getDefinition();
         $this->assertTrue($definition->hasArgument('name'));
         $this->assertTrue($definition->getArgument('name')->isRequired()); // Name is required to find the service
-        
+
         $this->assertTrue($definition->hasArgument('context'));
         $this->assertTrue($definition->getArgument('context')->isRequired()); // Context is required for the queue options provider
 

--- a/Tests/Command/MultipleConsumerCommandTest.php
+++ b/Tests/Command/MultipleConsumerCommandTest.php
@@ -3,11 +3,11 @@
 namespace OldSound\RabbitMqBundle\Tests\Command;
 
 use OldSound\RabbitMqBundle\Command\MultipleConsumerCommand;
-
 use Symfony\Component\Console\Input\InputOption;
 
-class MultipleConsumerCommandTest extends BaseCommandTest{
-    
+class MultipleConsumerCommandTest extends BaseCommandTest
+{
+
     protected function setUp()
     {
         parent::setUp();
@@ -25,7 +25,7 @@ class MultipleConsumerCommandTest extends BaseCommandTest{
         $this->command = new MultipleConsumerCommand();
         $this->command->setApplication($this->application);
     }
-    
+
     /**
      * testInputsDefinitionCommand
      */
@@ -35,7 +35,7 @@ class MultipleConsumerCommandTest extends BaseCommandTest{
         $definition = $this->command->getDefinition();
         $this->assertTrue($definition->hasArgument('name'));
         $this->assertTrue($definition->getArgument('name')->isRequired()); // Name is required to find the service
-        
+
         $this->assertTrue($definition->hasArgument('context'));
         $this->assertFalse($definition->getArgument('context')->isRequired()); // Context is required for the queue options provider
 

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -9,8 +9,9 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use OldSound\RabbitMqBundle\DependencyInjection\OldSoundRabbitMqExtension;
 use Symfony\Component\DependencyInjection\Reference;
+use PHPUnit\Framework\TestCase;
 
-class OldSoundRabbitMqExtensionTest extends \PHPUnit_Framework_TestCase
+class OldSoundRabbitMqExtensionTest extends TestCase
 {
     public function testFooConnectionDefinition()
     {

--- a/Tests/Event/AfterProcessingMessageEventTest.php
+++ b/Tests/Event/AfterProcessingMessageEventTest.php
@@ -5,13 +5,14 @@ namespace OldSound\RabbitMqBundle\Tests\Event;
 use OldSound\RabbitMqBundle\Event\AfterProcessingMessageEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class AfterProcessingMessageEventTest
  *
  * @package OldSound\RabbitMqBundle\Tests\Event
  */
-class AfterProcessingMessageEventTest extends \PHPUnit_Framework_TestCase
+class AfterProcessingMessageEventTest extends TestCase
 {
     protected function getConsumer()
     {

--- a/Tests/Event/BeforeProcessingMessageEventTest.php
+++ b/Tests/Event/BeforeProcessingMessageEventTest.php
@@ -5,13 +5,14 @@ namespace OldSound\RabbitMqBundle\Tests\Event;
 use OldSound\RabbitMqBundle\Event\BeforeProcessingMessageEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class BeforeProcessingMessageEventTest
  *
  * @package OldSound\RabbitMqBundle\Tests\Event
  */
-class BeforeProcessingMessageEventTest extends \PHPUnit_Framework_TestCase
+class BeforeProcessingMessageEventTest extends TestCase
 {
     protected function getConsumer()
     {

--- a/Tests/Event/OnIdleEventTest.php
+++ b/Tests/Event/OnIdleEventTest.php
@@ -4,13 +4,14 @@ namespace OldSound\RabbitMqBundle\Tests\Event;
 
 use OldSound\RabbitMqBundle\Event\OnIdleEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class OnIdleEventTest
  *
  * @package OldSound\RabbitMqBundle\Tests\Event
  */
-class OnIdleEventTest extends \PHPUnit_Framework_TestCase
+class OnIdleEventTest extends TestCase
 {
     protected function getConsumer()
     {

--- a/Tests/Manager/MemoryCheckerTest.php
+++ b/Tests/Manager/MemoryCheckerTest.php
@@ -4,13 +4,14 @@ namespace OldSound\RabbitMqBundle\Tests\Event;
 
 use OldSound\RabbitMqBundle\MemoryChecker\MemoryConsumptionChecker;
 use OldSound\RabbitMqBundle\MemoryChecker\NativeMemoryUsageProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MemoryManagerTest
  *
  * @package OldSound\RabbitMqBundle\Tests\Manager
  */
-class MemoryConsumptionCheckerTest extends \PHPUnit_Framework_TestCase
+class MemoryConsumptionCheckerTest extends TestCase
 {
     public function testMemoryIsNotAlmostOverloaded()
     {

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -5,8 +5,9 @@ namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 use OldSound\RabbitMqBundle\Provider\ConnectionParametersProviderInterface;
 use OldSound\RabbitMqBundle\RabbitMq\AMQPConnectionFactory;
 use OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection;
+use PHPUnit\Framework\TestCase;
 
-class AMQPConnectionFactoryTest extends \PHPUnit_Framework_TestCase
+class AMQPConnectionFactoryTest extends TestCase
 {
     public function testDefaultValues()
     {

--- a/Tests/RabbitMq/BaseAmqpTest.php
+++ b/Tests/RabbitMq/BaseAmqpTest.php
@@ -5,8 +5,9 @@ namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 use OldSound\RabbitMqBundle\Event\AMQPEvent;
 use OldSound\RabbitMqBundle\RabbitMq\BaseAmqp;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+use PHPUnit\Framework\TestCase;
 
-class BaseAmqpTest extends \PHPUnit_Framework_TestCase
+class BaseAmqpTest extends TestCase
 {
 
     public function testLazyConnection()

--- a/Tests/RabbitMq/BaseConsumerTest.php
+++ b/Tests/RabbitMq/BaseConsumerTest.php
@@ -3,8 +3,9 @@
 namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 
 use OldSound\RabbitMqBundle\RabbitMq\BaseConsumer;
+use PHPUnit\Framework\TestCase;
 
-class BaseConsumerTest extends \PHPUnit_Framework_TestCase
+class BaseConsumerTest extends TestCase
 {
     /** @var BaseConsumer */
     protected $consumer;

--- a/Tests/RabbitMq/BindingTest.php
+++ b/Tests/RabbitMq/BindingTest.php
@@ -2,10 +2,10 @@
 
 namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 
-
 use OldSound\RabbitMqBundle\RabbitMq\Binding;
+use PHPUnit\Framework\TestCase;
 
-class BindingTest extends \PHPUnit_Framework_TestCase
+class BindingTest extends TestCase
 {
 
     protected function getBinding($amqpConnection, $amqpChannel)

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -10,9 +10,10 @@ use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
+use PHPUnit\Framework\TestCase;
 
-class ConsumerTest extends \PHPUnit_Framework_TestCase
-{   
+class ConsumerTest extends TestCase
+{
     protected function getConsumer($amqpConnection, $amqpChannel)
     {
         return new Consumer($amqpConnection, $amqpChannel);

--- a/Tests/RabbitMq/DynamicConsumerTest.php
+++ b/Tests/RabbitMq/DynamicConsumerTest.php
@@ -5,12 +5,12 @@ namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 use OldSound\RabbitMqBundle\RabbitMq\DynamicConsumer;
 
 class DynamicConsumerTest extends ConsumerTest
-{   
+{
     public function getConsumer($amqpConnection, $amqpChannel)
     {
         return new DynamicConsumer($amqpConnection, $amqpChannel);
     }
-    
+
     /**
      * Preparing QueueOptionsProviderInterface instance
      *
@@ -21,14 +21,14 @@ class DynamicConsumerTest extends ConsumerTest
         return $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueueOptionsProviderInterface')
             ->getMock();
     }
-    
+
     public function testQueueOptionsPrivider()
     {
         $amqpConnection = $this->prepareAMQPConnection();
         $amqpChannel = $this->prepareAMQPChannel();
         $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
         $consumer->setContext('foo');
-        
+
         $queueOptionsProvider = $this->prepareQueueOptionsProvider();
         $queueOptionsProvider->expects($this->once())
             ->method('getQueueOptions')
@@ -40,12 +40,12 @@ class DynamicConsumerTest extends ConsumerTest
                     )
                 )
             ));
-        
+
         $consumer->setQueueOptionsProvider($queueOptionsProvider);
-        
+
         $reflectionClass = new \ReflectionClass(get_class($consumer));
         $reflectionMethod = $reflectionClass->getMethod('mergeQueueOptions');
         $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($consumer);        
+        $reflectionMethod->invoke($consumer);
     }
 }

--- a/Tests/RabbitMq/MultipleConsumerTest.php
+++ b/Tests/RabbitMq/MultipleConsumerTest.php
@@ -8,8 +8,9 @@ use OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 
-class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
+class MultipleConsumerTest extends TestCase
 {
     /**
      * Multiple consumer
@@ -111,13 +112,13 @@ class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
         $this->multipleConsumer->processQueueMessage('test-1', $amqpMessage);
         $this->multipleConsumer->processQueueMessage('test-2', $amqpMessage);
     }
-    
+
     public function testQueuesPrivider()
     {
         $amqpConnection = $this->prepareAMQPConnection();
         $amqpChannel = $this->prepareAMQPChannel();
         $this->multipleConsumer->setContext('foo');
-        
+
         $queuesProvider = $this->prepareQueuesProvider();
         $queuesProvider->expects($this->once())
             ->method('getQueues')
@@ -126,13 +127,13 @@ class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
                     'queue_foo' => array()
                 )
             ));
-        
+
         $this->multipleConsumer->setQueuesProvider($queuesProvider);
-        
+
         $reflectionClass = new \ReflectionClass(get_class($this->multipleConsumer));
         $reflectionMethod = $reflectionClass->getMethod('mergeQueues');
         $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($this->multipleConsumer);        
+        $reflectionMethod->invoke($this->multipleConsumer);
     }
 
     /**
@@ -268,4 +269,4 @@ class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
             return $processFlag;
         };
     }
-} 
+}

--- a/Tests/RabbitMq/RpcClientTest.php
+++ b/Tests/RabbitMq/RpcClientTest.php
@@ -4,8 +4,9 @@ namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 
 use OldSound\RabbitMqBundle\RabbitMq\RpcClient;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 
-class RpcClientTest extends \PHPUnit_Framework_TestCase
+class RpcClientTest extends TestCase
 {
     public function testProcessMessageWithCustomUnserializer()
     {

--- a/Tests/RabbitMq/RpcServerTest.php
+++ b/Tests/RabbitMq/RpcServerTest.php
@@ -4,8 +4,9 @@ namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 
 use OldSound\RabbitMqBundle\RabbitMq\RpcServer;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\TestCase;
 
-class RpcServerTest extends \PHPUnit_Framework_TestCase
+class RpcServerTest extends TestCase
 {
     public function testProcessMessageWithCustomSerializer()
     {
@@ -38,4 +39,3 @@ class RpcServerTest extends \PHPUnit_Framework_TestCase
         $server->processMessage($message);
     }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "symfony/serializer":           "^2.7|^3.0|^4.0",
         "symfony/debug":                "^2.7|^3.0|^4.0",
-        "phpunit/phpunit":              "^4.8|^5.0"
+        "phpunit/phpunit":              "^4.8.35|^5.4.3"
     },
     "replace": {
         "oldsound/rabbitmq-bundle": "self.version"


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).