### PR TITLE
Use symfony service locator feature instead of making public services

### DIFF
--- a/Command/BaseRabbitMqCommand.php
+++ b/Command/BaseRabbitMqCommand.php
@@ -2,9 +2,11 @@
 
 namespace OldSound\RabbitMqBundle\Command;
 
+
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 
 abstract class BaseRabbitMqCommand extends Command implements ContainerAwareInterface
 {
@@ -12,6 +14,20 @@ abstract class BaseRabbitMqCommand extends Command implements ContainerAwareInte
      * @var ContainerInterface
      */
     protected $container;
+
+    /**
+     * @var PsrContainerInterface
+     */
+    protected $psrContainer;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($name = null, PsrContainerInterface $container = null)
+    {
+        $this->psrContainer = $container;
+        parent::__construct($name);
+    }
 
     /**
      * {@inheritDoc}
@@ -22,10 +38,10 @@ abstract class BaseRabbitMqCommand extends Command implements ContainerAwareInte
     }
 
     /**
-     * @return ContainerInterface
+     * @return ContainerInterface|PsrContainerInterface
      */
     public function getContainer()
     {
-        return $this->container;
+        return $this->psrContainer ?: $this->psrContainer;
     }
 }

--- a/DependencyInjection/Compiler/RegisterProducerConsumerServicesPass.php
+++ b/DependencyInjection/Compiler/RegisterProducerConsumerServicesPass.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterProducerConsumerServicesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!class_exists(ServiceLocatorTagPass::class)) {
+            return;
+        }
+
+        $types = [
+            'old_sound_rabbit_mq.consumer'=> 'old_sound_rabbit_mq.consumer.command'
+        ];
+
+        foreach ($types as $type => $commandType) {
+            $services = $container->findTaggedServiceIds($type);
+            $handlerServices = array();
+
+            foreach ($services as $id => $tagParams) {
+                $handlerServices[$id] = new Reference($id);
+            }
+            $serviceLocator = ServiceLocatorTagPass::register($container, $handlerServices);
+
+            $commands = $container->findTaggedServiceIds($commandType);
+            foreach ($commands as $id => $tagParams) {
+                $container->getDefinition($id)->setArgument(1, $serviceLocator);
+            }
+        }
+    }
+}

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -261,7 +261,6 @@ class OldSoundRabbitMqExtension extends Extension
             }
 
             $definition = new Definition('%old_sound_rabbit_mq.multi_consumer.class%');
-            $definition->setPublic(true);
             $definition
                 ->addTag('old_sound_rabbit_mq.base_amqp')
                 ->addTag('old_sound_rabbit_mq.multi_consumer')

--- a/OldSoundRabbitMqBundle.php
+++ b/OldSoundRabbitMqBundle.php
@@ -4,6 +4,7 @@ namespace OldSound\RabbitMqBundle;
 
 use OldSound\RabbitMqBundle\DependencyInjection\Compiler\InjectEventDispatcherPass;
 use OldSound\RabbitMqBundle\DependencyInjection\Compiler\RegisterPartsPass;
+use OldSound\RabbitMqBundle\DependencyInjection\Compiler\RegisterProducerConsumerServicesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -15,6 +16,7 @@ class OldSoundRabbitMqBundle extends Bundle
 
         $container->addCompilerPass(new RegisterPartsPass());
         $container->addCompilerPass(new InjectEventDispatcherPass());
+        $container->addCompilerPass(new RegisterProducerConsumerServicesPass());
     }
 
     /**

--- a/Resources/config/rabbitmq.xml
+++ b/Resources/config/rabbitmq.xml
@@ -38,6 +38,7 @@
 
         <service id="old_sound_rabbit_mq.batch_consumer_command" class="OldSound\RabbitMqBundle\Command\BatchConsumerCommand">
             <tag name="console.command" command="rabbitmq:batch:consumer" />
+            <tag name="old_sound_rabbit_mq.consumer.command"/>
         </service>
 
         <service id="old_sound_rabbit_mq.consumer_command" class="OldSound\RabbitMqBundle\Command\ConsumerCommand">
@@ -46,6 +47,7 @@
 
         <service id="old_sound_rabbit_mq.delete_command" class="OldSound\RabbitMqBundle\Command\DeleteCommand">
             <tag name="console.command" command="rabbitmq:delete" />
+            <tag name="old_sound_rabbit_mq.consumer.command"/>
         </service>
 
         <service id="old_sound_rabbit_mq.dynamic_consumer_command" class="OldSound\RabbitMqBundle\Command\DynamicConsumerCommand">
@@ -57,7 +59,8 @@
         </service>
 
         <service id="old_sound_rabbit_mq.purge_consumer_command" class="OldSound\RabbitMqBundle\Command\PurgeConsumerCommand">
-            <tag name="console.command" command="rabbitmq:multiple-consumer" />
+            <tag name="console.command" command="rabbitmq:purge" />
+            <tag name="old_sound_rabbit_mq.consumer.command"/>
         </service>
 
         <service id="old_sound_rabbit_mq.command.rpc_server_command" class="OldSound\RabbitMqBundle\Command\RpcServerCommand">

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "symfony/yaml":                 "^2.7|^3.0|^4.0",
         "symfony/console":              "^2.7|^3.0|^4.0",
         "php-amqplib/php-amqplib":      "^2.6",
+        "psr/container":                "^1.0",
         "psr/log":                      "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is an alternative approach to making the services public. It uses the symfony service locator feature (it is a PSR container with limited scope to a group of services that are made public only for that sub-container)

https://symfony.com/blog/new-in-symfony-3-3-service-locators

I've merged something similar here https://github.com/schmittjoh/JMSSerializerBundle/pull/618

The PR is not complete, if is interesting I can continue to work on it