### PR TITLE
Concept: Container should not be touched directly

### DIFF
--- a/Command/ConsumerCommand.php
+++ b/Command/ConsumerCommand.php
@@ -2,6 +2,8 @@
 
 namespace OldSound\RabbitMqBundle\Command;
 
+use OldSound\RabbitMqBundle\DependencyInjection\ServiceNameFormat;
+
 class ConsumerCommand extends BaseConsumerCommand
 {
     protected function configure()
@@ -13,6 +15,6 @@ class ConsumerCommand extends BaseConsumerCommand
 
     protected function getConsumerService()
     {
-        return 'old_sound_rabbit_mq.%s_consumer';
+        return ServiceNameFormat::CONSUMER;
     }
 }

--- a/DependencyInjection/ConsumerBag.php
+++ b/DependencyInjection/ConsumerBag.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\DependencyInjection;
+
+use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+
+class ConsumerBag
+{
+    /** @var Consumer[] */
+    private $consumers = [];
+
+    public function addConsumer($key, $consumer) : void
+    {
+        $this->consumers[$key] = $consumer;
+    }
+
+    /**
+     * @return Consumer[]
+     */
+    public function getConsumers() : array
+    {
+        return $this->consumers;
+    }
+
+    public function findConsumerByKey(string $name)
+    {
+        return $this->consumers[$name] ?? null;
+    }
+}

--- a/DependencyInjection/ServiceNameFormat.php
+++ b/DependencyInjection/ServiceNameFormat.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\DependencyInjection;
+
+class ServiceNameFormat
+{
+    const CONSUMER = 'old_sound_rabbit_mq.%s_consumer';
+}


### PR DESCRIPTION
This is concept how this bundle should work without using `container->get(service_id)`. The Symfony already throws deprecation notices about such usage.

> User Deprecated: The "old_sound_rabbit_mq.a_producer_producer" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead

If this looks good to you, I'm willing to rewrite such container usages in whole project.