### PR TITLE
fix  problem about rabbitmqBundle's rpc, when use symfony4

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -104,6 +104,7 @@ class OldSoundRabbitMqExtension extends Extension
                 $definition->setFactoryMethod('createConnection');
             }
             $definition->addTag('old_sound_rabbit_mq.connection');
+            $definition->setPublic(true);
 
             $this->container->setDefinition(sprintf('old_sound_rabbit_mq.connection.%s', $key), $definition);
         }
@@ -511,6 +512,7 @@ class OldSoundRabbitMqExtension extends Extension
             if (array_key_exists('direct_reply_to', $client)) {
                 $definition->addMethodCall('setDirectReplyTo', array($client['direct_reply_to']));
             }
+            $definition->setPublic(true);
 
             $this->container->setDefinition(sprintf('old_sound_rabbit_mq.%s_rpc', $key), $definition);
         }


### PR DESCRIPTION
find the problem like below:
```bash
[vagrant@bogon s4]$ php bin/console  rabbitmq:rpc-server test_server -vvv
2018-01-03T08:00:17+00:00 [error] Error thrown while running command "rabbitmq:rpc-server test_server -vvv". Message: "The "old_sound_rabbit_mq.test_server_server" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead."
2018-01-03T08:00:17+00:00 [debug] Command "rabbitmq:rpc-server test_server -vvv" exited with code "1"
```

In Container.php line 252:
```
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
  The "old_sound_rabbit_mq.test_server_server" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection
   instead.
 ```