### PR TITLE
AMPQ Interop migration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "symfony/yaml":                 "^2.7|^3.0|^4.0",
         "symfony/console":              "^2.7|^3.0|^4.0",
         "php-amqplib/php-amqplib":      "^2.6",
+        "enqueue/amqp-lib":             "^0.8",
         "psr/log":                      "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
The migration to [AMQP Interop](https://github.com/queue-interop/queue-interop#amqp-interop) brings several benefits:

* The producer can be configured to send a message with delay, TTL, and priority.
* Consumer supports PsrProcessor. The code in a processor is not coupled to AMQP, so it could be used with any other [interop compatible transports](https://github.com/queue-interop/queue-interop#implementations). It would be easy to use processors from libraries, like [this](https://github.com/php-enqueue/monolog-queue-handler/blob/master/src/AmqpHandler.php), or [this](https://github.com/liip/LiipImagineBundle/blob/1.0/Async/ResolveCacheProcessor.php), or [this](https://github.com/php-enqueue/enqueue-elastica-bundle/blob/master/Queue/PopulateProcessor.php)
* Stable, semantic OO API. 
* In future it would be possible to use the bundle not only with [php-amqplib](https://github.com/php-amqplib/php-amqplib) but [bunny](https://github.com/jakubkulhan/bunny) or [amqp-ext](https://github.com/pdezwart/php-amqp) as well. So there is no need in creating [same bundle but for amqp ext](https://github.com/M6Web/AmqpBundle) for example.



**The goal is to do migration as backward compatible as possible.**

**At the end, there wont be a dependency on enqueue, only amqp-interop**