### PR TITLE
Set headers if application_headers key in queueOptions

### DIFF
--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -246,7 +246,8 @@ abstract class BaseAmqp
     {
         // queue binding is not permitted on the default exchange
         if ('' !== $exchange) {
-            $this->getChannel()->queue_bind($queue, $exchange, $routing_key);
+            $this->getChannel()->queue_bind($queue, $exchange, $routing_key, false,
+                isset($this->queueOptions['application_headers']) ? $this->queueOptions['application_headers'] : null);
         }
     }
 


### PR DESCRIPTION
Sets headers on the queue during bind if `application_headers` is passed in via `queueOptions`. 