### PR TITLE
Make RPC servers public to avoid errors with Symfony 4

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -540,7 +540,8 @@ class OldSoundRabbitMqExtension extends Extension
                 ->addTag('old_sound_rabbit_mq.base_amqp')
                 ->addTag('old_sound_rabbit_mq.rpc_server')
                 ->addMethodCall('initServer', array($key))
-                ->addMethodCall('setCallback', array(array(new Reference($server['callback']), 'execute')));
+                ->addMethodCall('setCallback', array(array(new Reference($server['callback']), 'execute')))
+                ->setPublic(true);
             $this->injectConnection($definition, $server['connection']);
             if ($this->collectorEnabled) {
                 $this->injectLoggedChannel($definition, $key, $server['connection']);


### PR DESCRIPTION
Maybe I'm wrong, but I think #515 pull request didn't fix completely the problem with Symfony 4, as I'm still getting this error even after the previous fix :

In Container.php line 252:
`The "old_sound_rabbit_mq.XXXX_server" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.`

My commit fixed my problem.