### PR TITLE
Set dynamic consumer public (bugfix for Symfony 4)

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -336,6 +336,7 @@ class OldSoundRabbitMqExtension extends Extension
             }
 
             $definition = new Definition('%old_sound_rabbit_mq.dynamic_consumer.class%');
+            $definition->setPublic(true);
             $definition
                 ->addTag('old_sound_rabbit_mq.base_amqp')
                 ->addTag('old_sound_rabbit_mq.consumer')


### PR DESCRIPTION
Sets dynamic consumers public and fixes this bug that appears in Symfony 4:
"The "old_sound_rabbit_mq.XXX_dynamic" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead."