### PR TITLE
AMQPSocketConnection has a different parameters order, lets consider it

### DIFF
--- a/Provider/ConnectionParametersProviderInterface.php
+++ b/Provider/ConnectionParametersProviderInterface.php
@@ -25,7 +25,11 @@ interface ConnectionParametersProviderInterface
      *   'keepalive' => false,
      *   'heartbeat' => 0,
      *   'use_socket' => true,
+     *   'constructor_args' => array(...)
      * )
+     *
+     * If constructor_args is present, all the other parameters are ignored; constructor_args are passes as constructor
+     * arguments.
      *
      * @return array
      */

--- a/RabbitMq/AMQPConnectionFactory.php
+++ b/RabbitMq/AMQPConnectionFactory.php
@@ -60,22 +60,40 @@ class AMQPConnectionFactory
      */
     public function createConnection()
     {
-        return new $this->class(
-            $this->parameters['host'],
-            $this->parameters['port'],
-            $this->parameters['user'],
-            $this->parameters['password'],
-            $this->parameters['vhost'],
-            false,      // insist
-            'AMQPLAIN', // login_method
-            null,       // login_response
-            'en_US',    // locale
-            $this->parameters['connection_timeout'],
-            $this->parameters['read_write_timeout'],
-            $this->parameters['ssl_context'],
-            $this->parameters['keepalive'],
-            $this->parameters['heartbeat']
-        );
+        if ($this->class == 'PhpAmqpLib\Connection\AMQPSocketConnection' || is_subclass_of($this->class , 'PhpAmqpLib\Connection\AMQPSocketConnection')) {
+            return new $this->class(
+                $this->parameters['host'],
+                $this->parameters['port'],
+                $this->parameters['user'],
+                $this->parameters['password'],
+                $this->parameters['vhost'],
+                false,      // insist
+                'AMQPLAIN', // login_method
+                null,       // login_response
+                'en_US',    // locale
+                isset($this->parameters['read_timeout']) ? $this->parameters['read_timeout'] : $this->parameters['read_write_timeout'],
+                $this->parameters['keepalive'],
+                isset($this->parameters['write_timeout']) ? $this->parameters['write_timeout'] : $this->parameters['read_write_timeout'],
+                $this->parameters['heartbeat']
+            );
+        } else {
+            return new $this->class(
+                $this->parameters['host'],
+                $this->parameters['port'],
+                $this->parameters['user'],
+                $this->parameters['password'],
+                $this->parameters['vhost'],
+                false,      // insist
+                'AMQPLAIN', // login_method
+                null,       // login_response
+                'en_US',    // locale
+                $this->parameters['connection_timeout'],
+                $this->parameters['read_write_timeout'],
+                $this->parameters['ssl_context'],
+                $this->parameters['keepalive'],
+                $this->parameters['heartbeat']
+            );
+        }
     }
 
     /**

--- a/RabbitMq/AMQPConnectionFactory.php
+++ b/RabbitMq/AMQPConnectionFactory.php
@@ -60,6 +60,11 @@ class AMQPConnectionFactory
      */
     public function createConnection()
     {
+        if (isset($this->parameters['constructor_args']) && is_array($this->parameters['constructor_args'])) {
+            $ref = new \ReflectionClass($this->class);
+            return $ref->newInstanceArgs($this->parameters['constructor_args']);
+        }
+
         if ($this->class == 'PhpAmqpLib\Connection\AMQPSocketConnection' || is_subclass_of($this->class , 'PhpAmqpLib\Connection\AMQPSocketConnection')) {
             return new $this->class(
                 $this->parameters['host'],

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -269,6 +269,28 @@ class AMQPConnectionFactoryTest extends TestCase
         ), $instance->constructParams);
     }
 
+    public function testConnectionsParametersProviderWithConstructorArgs()
+    {
+        $connectionParametersProvider = $this->prepareConnectionParametersProvider();
+        $connectionParametersProvider->expects($this->once())
+            ->method('getConnectionParameters')
+            ->will($this->returnValue(
+                array(
+                    'constructor_args' => array(1,2,3,4)
+                )
+            ));
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection',
+            array(),
+            $connectionParametersProvider
+        );
+
+        /** @var AMQPConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection', $instance);
+        $this->assertEquals(array(1,2,3,4), $instance->constructParams);
+    }
+
     public function testConnectionsParametersProvider()
     {
         $connectionParametersProvider = $this->prepareConnectionParametersProvider();

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -5,6 +5,7 @@ namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
 use OldSound\RabbitMqBundle\Provider\ConnectionParametersProviderInterface;
 use OldSound\RabbitMqBundle\RabbitMq\AMQPConnectionFactory;
 use OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection;
+use OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection;
 use PHPUnit\Framework\TestCase;
 
 class AMQPConnectionFactoryTest extends TestCase
@@ -33,6 +34,63 @@ class AMQPConnectionFactoryTest extends TestCase
             3,           // read write timeout
             null,        // context
             false,       // keepalive
+            0,           // heartbeat
+        ), $instance->constructParams);
+    }
+
+    public function testSocketConnection()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection',
+            array()
+        );
+
+        /** @var AMQPSocketConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('PhpAmqpLib\Connection\AMQPSocketConnection', $instance);
+        $this->assertEquals(array(
+            'localhost', // host
+            5672,        // port
+            'guest',     // user
+            'guest',     // password
+            '/',         // vhost
+            false,       // insist
+            "AMQPLAIN",  // login method
+            null,        // login response
+            "en_US",     // locale
+            3,           // read_timeout
+            false,       // keepalive
+            3,           // write_timeout
+            0,           // heartbeat
+        ), $instance->constructParams);
+    }
+
+    public function testSocketConnectionWithParams()
+    {
+        $factory = new AMQPConnectionFactory(
+            'OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection',
+            array(
+                'read_timeout' => 31,
+                'write_timeout' => 32,
+            )
+        );
+
+        /** @var AMQPSocketConnection $instance */
+        $instance = $factory->createConnection();
+        $this->assertInstanceOf('PhpAmqpLib\Connection\AMQPSocketConnection', $instance);
+        $this->assertEquals(array(
+            'localhost', // host
+            5672,        // port
+            'guest',     // user
+            'guest',     // password
+            '/',         // vhost
+            false,       // insist
+            "AMQPLAIN",  // login method
+            null,        // login response
+            "en_US",     // locale
+            31,           // read_timeout
+            false,       // keepalive
+            32,           // write_timeout
             0,           // heartbeat
         ), $instance->constructParams);
     }

--- a/Tests/RabbitMq/Fixtures/AMQPSocketConnection.php
+++ b/Tests/RabbitMq/Fixtures/AMQPSocketConnection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures;
+
+use PhpAmqpLib\Connection\AMQPSocketConnection as BaseAMQPSocketConnection;
+
+class AMQPSocketConnection extends BaseAMQPSocketConnection
+{
+    public $constructParams;
+
+    public function __construct()
+    {
+        // save params for direct access in tests
+        $this->constructParams = func_get_args();
+    }
+}


### PR DESCRIPTION
`AMQPSocketConnection` has a different parameter ordering than `AMQPStreamConnection`

Currently the example on how to use sockets connection does not work.
You will always get 
```
[PhpAmqpLib\Exception\AMQPIOException]                      
Error reading data. Received 0 instead of expected 7 bytes  
```

To solve is necessary to pass `read_timeout` = 0 or a higher value to the `AMQPSocketConnection` class.

I guess this can be "solved"  by `connection_parameters_provider`, but since sockets looks to be supported natively  by the bundle they should work almost out of the box.

Ive spent days trying to setup socket connections.
