### PR TITLE
Fix rpc client for symfony 4

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -513,6 +513,7 @@ class OldSoundRabbitMqExtension extends Extension
         foreach ($this->config['rpc_clients'] as $key => $client) {
             $definition = new Definition('%old_sound_rabbit_mq.rpc_client.class%');
             $definition->setLazy($client['lazy']);
+            $definition->setPublic(true);
             $definition
                 ->addTag('old_sound_rabbit_mq.rpc_client')
                 ->addMethodCall('initClient', array($client['expect_serialized_response']));


### PR DESCRIPTION
rpc-clients definition need to be public for the symfony4 dependency injection