### PR TITLE
Add methods to batch publish messages

### DIFF
--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -42,16 +42,7 @@ class Producer extends BaseAmqp implements ProducerInterface
      */
     public function publish($msgBody, $routingKey = '', $additionalProperties = array(), array $headers = null)
     {
-        if ($this->autoSetupFabric) {
-            $this->setupFabric();
-        }
-
-        $msg = new AMQPMessage((string) $msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
-
-        if (!empty($headers)) {
-            $headersTable = new AMQPTable($headers);
-            $msg->set('application_headers', $headersTable);
-        }
+        $msg = $this->createAMQPMessage($msgBody, $additionalProperties, $headers);
 
         $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string)$routingKey);
         $this->logger->debug('AMQP message published', array(
@@ -62,5 +53,61 @@ class Producer extends BaseAmqp implements ProducerInterface
                 'headers' => $headers
             )
         ));
+    }
+
+    /**
+     * Adds a message to an array to be batch published later on
+     * Merges additional properties with basic properties
+     *
+     * @param string $msgBody
+     * @param string $routingKey
+     * @param array $additionalProperties
+     * @param array $headers
+     */
+    public function addToBatch($msgBody, $routingKey = '', $additionalProperties = array(), array $headers = null)
+    {
+        $msg = $this->createAMQPMessage($msgBody, $additionalProperties, $headers);
+
+        $this->getChannel()->batch_basic_publish($msg, $this->exchangeOptions['name'], (string)$routingKey);
+        $this->logger->debug('AMQP message added to batch', array(
+            'amqp' => array(
+                'body' => $msgBody,
+                'routingkeys' => $routingKey,
+                'properties' => $additionalProperties,
+                'headers' => $headers
+            )
+        ));
+    }
+
+    /**
+     * Publish the messages that are in the batch
+     */
+    public function publishBatch()
+    {
+        $this->getChannel()->publish_batch();
+        $this->logger->debug('AMQP published batch');
+    }
+
+    /**
+     * @param string $msgBody
+     * @param array $additionalProperties
+     * @param array $headers
+     *
+     * @return AMQPMessage
+     */
+    private function createAMQPMessage($msgBody, $additionalProperties = array(), array $headers = null)
+    {
+        if ($this->autoSetupFabric) {
+            $this->setupFabric();
+        }
+
+        $msg = new AMQPMessage((string)$msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
+
+        if (!empty($headers)) {
+            $headersTable = new AMQPTable($headers);
+            $msg->set('application_headers', $headersTable);
+        }
+
+        return $msg;
     }
 }

--- a/RabbitMq/ProducerInterface.php
+++ b/RabbitMq/ProducerInterface.php
@@ -10,6 +10,22 @@ interface ProducerInterface
      * @param string $msgBody
      * @param string $routingKey
      * @param array $additionalProperties
+     * @param array $headers
      */
-    public function publish($msgBody, $routingKey = '', $additionalProperties = array());
+    public function publish($msgBody, $routingKey = '', $additionalProperties = array(), array $headers = null);
+
+    /**
+     * Add a message to a batch
+     *
+     * @param string $msgBody
+     * @param string $routingKey
+     * @param array $additionalProperties
+     * @param array $headers
+     */
+    public function addToBatch($msgBody, $routingKey = '', $additionalProperties = array(), array $headers = null);
+
+    /**
+     * @return void
+     */
+    public function publishBatch();
 }


### PR DESCRIPTION
PhpAmqpLib supports batch publishing of messages to RabbitMQ, added methods to the ProducerInterface to make this available in the bundle.