### PR TITLE
- Batch Consumer has basic_cancel with noreturn flag to terminate loop #550

### DIFF
--- a/RabbitMq/BatchConsumer.php
+++ b/RabbitMq/BatchConsumer.php
@@ -322,7 +322,7 @@ class BatchConsumer extends BaseAmqp implements DequeuerInterface
             $this->batchConsume();
         }
 
-        $this->getChannel()->basic_cancel($this->getConsumerTag());
+        $this->getChannel()->basic_cancel($this->getConsumerTag(), false, true);
     }
 
     /**


### PR DESCRIPTION
In relation to issue that BatchConsumer can get stuck (Issue #550)

