### PR TITLE
Set the Producer alias to be public for Symfony 4 compatibility

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -169,7 +169,8 @@ class OldSoundRabbitMqExtension extends Extension
 
                 $this->container->setDefinition($producerServiceName, $definition);
                 if (null !== $producer['service_alias']) {
-                    $this->container->setAlias($producer['service_alias'], $producerServiceName);
+                    $alias = $this->container->setAlias($producer['service_alias'], $producerServiceName);
+                    $alias->setPublic(true);
                 }
             }
         } else {


### PR DESCRIPTION
This allows developers to reference the `service_alias` of the Producer within PHP classes.

Currently, the Producer definition is marked as public, but the alias is not.