### PR TITLE
550-Force exit the batch consumer if gracefullExecutionTimeout

### DIFF
--- a/RabbitMq/BatchConsumer.php
+++ b/RabbitMq/BatchConsumer.php
@@ -323,6 +323,7 @@ class BatchConsumer extends BaseAmqp implements DequeuerInterface
         }
 
         $this->getChannel()->basic_cancel($this->getConsumerTag());
+        exit;
     }
 
     /**


### PR DESCRIPTION
Related to issue #550 
The batch consumer is force to exit if stopConsuming() is called.