### PR TITLE
Fix: Deprecation: A tree builder without a root node is deprecated since symfony 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,9 +30,14 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
+        $tree = new TreeBuilder($this->name);
 
-        $rootNode = $tree->root($this->name);
+        if (\method_exists($tree, 'getRootNode')) {
+            $rootNode = $tree->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $tree->root($this->name);
+        }
 
         $rootNode
             ->children()
@@ -217,7 +222,7 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
     }
-    
+
     protected function addDynamicConsumers(ArrayNodeDefinition $node)
     {
         $node


### PR DESCRIPTION
Fix deprecation for symfony/config 4.2