### PR TITLE
Fix expiration configuration parameter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,12 +606,12 @@ rpc_clients:
         expect_serialized_response: false
 ```
 
-You can also set a expiration for request in seconds, after which message will no longer be handled by server and client request will simply time out. Setting expiration for messages works only for RabbitMQ 3.x and above. Visit http://www.rabbitmq.com/ttl.html#per-message-ttl for more information.
+You can also set a expiration for request in milliseconds, after which message will no longer be handled by server and client request will simply time out. Setting expiration for messages works only for RabbitMQ 3.x and above. Visit http://www.rabbitmq.com/ttl.html#per-message-ttl for more information.
 
 ```php
 public function indexAction($name)
 {
-    $expiration = 5; // seconds
+    $expiration = 5000; // milliseconds
     $client = $this->get('old_sound_rabbit_mq.integer_store_rpc');
     $client->addRequest($body, $server, $requestId, $routingKey, $expiration);
     try {


### PR DESCRIPTION
According to the RabbitMQ documentation expiration is set as milliseconds.

>The value of the expiration field describes the TTL period in milliseconds. The same constraints as for x-message-ttl apply. Since the expiration field must be a string, the broker will (only) accept the string representation of the number.

https://www.rabbitmq.com/ttl.html#per-message-ttl-in-publishers