### PR TITLE
Fix providing integer/boolean parameters via url.

### DIFF
--- a/RabbitMq/AMQPConnectionFactory.php
+++ b/RabbitMq/AMQPConnectionFactory.php
@@ -140,6 +140,20 @@ class AMQPConnectionFactory
         if (isset($url['query'])) {
             $query = array();
             parse_str($url['query'], $query);
+            foreach ($query as $key => $param){
+                if (isset($query['connection_timeout'])) {
+                    $query['connection_timeout'] = (int)$query['connection_timeout'];
+                }
+                if (isset($query['read_write_timeout'])) {
+                    $query['read_write_timeout'] = (int)$query['read_write_timeout'];
+                }
+                if (isset($query['keepalive'])) {
+                    $query['keepalive'] = (bool)$query['keepalive'];
+                }
+                if (isset($query['heartbeat'])) {
+                    $query['heartbeat'] = (int)$query['heartbeat'];
+                }
+            }
             $parameters = array_merge($parameters, $query);
         }
 


### PR DESCRIPTION
This pull request will fix providing parameters via url. Now when I want to provide heartbeat = 0 in the url, I'm getting this error because of missed strict typing:

> root@229442e4ab9f:/var/www/html/site# bin/console rabbitmq:consumer -m 50 consumer_name
> 
> In StreamIO.php line 390:
>                            
>   Missed server heartbeat  
>                            
> 
> rabbitmq:consumer [-m|--messages [MESSAGES]] [-r|--route [ROUTE]] [-l|--memory-limit [MEMORY-LIMIT]] [-d|--debug] [-w|--without-signals] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> <name>
> 
