### PR TITLE
avoid making deep merging for the connection's ssl context

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('read_write_timeout')->defaultValue(3)->end()
                             ->booleanNode('use_socket')->defaultValue(false)->end()
                             ->arrayNode('ssl_context')
+                                ->performNoDeepMerging()
                                 ->useAttributeAsKey('key')
                                 ->canBeUnset()
                                 ->prototype('variable')->end()


### PR DESCRIPTION
This solves the problem when overriding connection's ssl context should be removed.

For instance - in `services.yaml` (because we use ssl context in `test`, `staging` and `prod`)
```yaml
old_sound_rabbit_mq:
    connections:
        my_connection:
            url: '%url%'
            ssl_context:
                verify_peer: true
                cafile: '%cafile%'
                local_cert: '%loca_cert%'
```

And in `services_dev.yaml` (because we don't use ssl context in `dev`)
```yaml
old_sound_rabbit_mq:
    connections:
        my_connection:
            url: '%url%'
            ssl_context: ~
```

Then `my_connection` will work as expected in the `dev` environment.

NB: Of course it will be possible to remove `my_connection` from `services.yaml` and put it in all relevant `services_*.yaml` (test, staging, prod ...) but I think it's a bit better to have it as default one and then override only in relevant places like in `services_dev.yaml` here.