### PR TITLE
Feature/compatibility with symfony 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
     - php: 7.2
-      env: SYMFONY_VERSION=4.0.*
+      env: SYMFONY_VERSION=4.3.*
     - php: 7.1
       env: DEPENDENCIES=beta
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
+    - php: 7.2
+      env: SYMFONY_VERSION=4.0.*
     - php: 7.1
       env: DEPENDENCIES=beta
     - php: 7.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+- 2019-08-01
+    * Replaced Symfony\Component\EventDispatcher\Event with Symfony\Contracts\EventDispatcher\Event
+        for compatibility with Symfony >=4.3
+
 - 2017-01-22
     * Add `graceful_max_execution_timeout`
 

--- a/Event/AMQPEvent.php
+++ b/Event/AMQPEvent.php
@@ -4,7 +4,7 @@ namespace OldSound\RabbitMqBundle\Event;
 
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Message\AMQPMessage;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class AMQPEvent

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -269,8 +269,8 @@ abstract class BaseAmqp
     {
         if ($this->getEventDispatcher()) {
             $this->getEventDispatcher()->dispatch(
-                $eventName,
-                $event
+                $event,
+                $eventName
             );
         }
     }

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -8,6 +8,7 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 abstract class BaseAmqp
 {
@@ -267,11 +268,20 @@ abstract class BaseAmqp
      */
     protected function dispatchEvent($eventName, AMQPEvent $event)
     {
-        if ($this->getEventDispatcher()) {
-            $this->getEventDispatcher()->dispatch(
-                $event,
-                $eventName
-            );
+        $eventDispatcher = $this->getEventDispatcher();
+
+        if ($eventDispatcher) {
+            if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+                $eventDispatcher->dispatch(
+                    $event,
+                    $eventName
+                );
+            } else {
+                $eventDispatcher->dispatch(
+                    $eventName,
+                    $event
+                );
+            }
         }
     }
 

--- a/Tests/RabbitMq/BaseAmqpTest.php
+++ b/Tests/RabbitMq/BaseAmqpTest.php
@@ -57,7 +57,7 @@ class BaseAmqpTest extends TestCase
 
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(AMQPEvent::ON_CONSUME, new AMQPEvent())
+            ->with(new AMQPEvent(), AMQPEvent::ON_CONSUME)
             ->willReturn(true);
         $this->invokeMethod('dispatchEvent', $baseAmqpConsumer, array(AMQPEvent::ON_CONSUME, new AMQPEvent()));
     }

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -77,8 +77,8 @@ class ConsumerTest extends TestCase
         $eventDispatcher->expects($this->atLeastOnce())
             ->method('dispatch')
             ->withConsecutive(
-                array(BeforeProcessingMessageEvent::NAME, new BeforeProcessingMessageEvent($consumer, $amqpMessage)),
-                array(AfterProcessingMessageEvent::NAME, new AfterProcessingMessageEvent($consumer, $amqpMessage))
+                array(new BeforeProcessingMessageEvent($consumer, $amqpMessage), BeforeProcessingMessageEvent::NAME),
+                array(new AfterProcessingMessageEvent($consumer, $amqpMessage), AfterProcessingMessageEvent::NAME)
             )
             ->willReturn(true);
         $consumer->processMessage($amqpMessage);
@@ -174,7 +174,7 @@ class ConsumerTest extends TestCase
 
         $eventDispatcher->expects($this->exactly(count($consumerCallBacks)))
             ->method('dispatch')
-            ->with(OnConsumeEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'))
+            ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'), OnConsumeEvent::NAME)
             ->willReturn(true);
 
         $consumer->setEventDispatcher($eventDispatcher);
@@ -247,14 +247,14 @@ class ConsumerTest extends TestCase
 
         $eventDispatcher->expects($this->at(1))
             ->method('dispatch')
-            ->with(OnIdleEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'))
-            ->willReturnCallback(function($eventName, OnIdleEvent $event) {
+            ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'), OnIdleEvent::NAME)
+            ->willReturnCallback(function(OnIdleEvent $event, $eventName) {
                 $event->setForceStop(false);
             });
         $eventDispatcher->expects($this->at(3))
             ->method('dispatch')
-            ->with(OnIdleEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'))
-            ->willReturn(function($eventName, OnIdleEvent $event) {
+            ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'), OnIdleEvent::NAME)
+            ->willReturn(function(OnIdleEvent $event, $eventName) {
                 $event->setForceStop(true);
         });
 


### PR DESCRIPTION
When using the event dispatcher in Symfony >= 4.3 in combination with the RabbiMQ bundle, you get a deprecation warning:
`php.INFO: User Deprecated: Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.`.

To resolve this I've replaced the use statement in **AMQPEvent**: **Symfony\Component\EventDispatcher\Event** with the newer **Symfony\Contracts\EventDispatcher\Event** and changed the order of parameters passed to the **Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch** in **BaseAMQP** (Since Symfony 4.3 the order is flipped: first the event, second (optional) the event name).