### PR TITLE
Fix compatibility with Symfony 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 php:
+  - 7.3
   - 7.2
   - 7.1
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,14 @@ matrix:
   include:
     - dist: precise
       php: 5.3
-      env: SYMFONY_VERSION=2.7.*
+      env:
+        - SYMFONY_VERSION=2.7.*
+        - INCREASE_MEMORY=yes
     - dist: precise
       php: 5.3
-      env: SYMFONY_VERSION=2.8.*
+      env:
+        - SYMFONY_VERSION=2.8.*
+        - INCREASE_MEMORY=yes
 
     - php: 5.6
       env: COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
@@ -33,6 +37,8 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
+    - php: 7.1
+      env: SYMFONY_VERSION=4.3.*
     - php: 7.1
       env: DEPENDENCIES=beta
     - php: 7.2
@@ -47,6 +53,7 @@ env:
 
 before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available";
+  - if [ "$INCREASE_MEMORY" = "yes" ]; then echo "memory_limit = 2048M" > travis.php.ini && phpenv config-add travis.php.ini; fi;
   - if [ "$DEPENDENCIES" = "beta" ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle "$SYMFONY_VERSION"; fi
   - if [ "$COMPOSER_FLAGS" != "" ]; then composer update --prefer-dist --no-interaction --no-scripts $COMPOSER_FLAGS; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,9 @@ matrix:
     - php: 7.3
       env: SYMFONY_VERSION=4.3.*
     - php: 7.3
-      env: SYMFONY_VERSION=4.4.*
+      env:
+        - SYMFONY_VERSION=4.4.*
+        - DEPENDENCIES=dev
 
   allow_failures:
     - php: nightly
@@ -59,7 +61,7 @@ env:
 before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available";
   - if [ "$INCREASE_MEMORY" = "yes" ]; then echo "memory_limit = 2048M" > travis.php.ini && phpenv config-add travis.php.ini; fi;
-  - if [ "$DEPENDENCIES" = "beta" ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;
+  - if [ "$DEPENDENCIES" != "" ]; then perl -pi -e 's/^}$/,"minimum-stability":"$DEPENDENCIES"}/' composer.json; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle "$SYMFONY_VERSION"; fi
   - if [ "$COMPOSER_FLAGS" != "" ]; then composer update --prefer-dist --no-interaction --no-scripts $COMPOSER_FLAGS; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ matrix:
       env: DEPENDENCIES=beta
     - php: 7.2
       env: DEPENDENCIES=beta
+    - php: 7.3
+      env: SYMFONY_VERSION=4.3.*
+    - php: 7.3
+      env: SYMFONY_VERSION=4.4.*
 
   allow_failures:
     - php: nightly

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+- 2019-10-22
+     * Replaced Symfony\Component\EventDispatcher\Event with Symfony\Contracts\EventDispatcher\Event
+         for compatibility with Symfony >=4.3
+
 - 2017-01-22
     * Add `graceful_max_execution_timeout`
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $tree = new TreeBuilder($this->name);
-        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode') ? $tree->getRootNode() : $tree->root($this->name);
+        $rootNode = \method_exists('\Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode') ? $tree->getRootNode() : $tree->root($this->name);
 
         $rootNode
             ->children()

--- a/Event/AMQPEvent.php
+++ b/Event/AMQPEvent.php
@@ -5,67 +5,134 @@ namespace OldSound\RabbitMqBundle\Event;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Message\AMQPMessage;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
 
-/**
- * Class AMQPEvent
- *
- * @package OldSound\RabbitMqBundle\Event
- * @codeCoverageIgnore
- */
-class AMQPEvent extends Event
-{
-    const ON_CONSUME                = 'on_consume';
-    const ON_IDLE                   = 'on_idle';
-    const BEFORE_PROCESSING_MESSAGE = 'before_processing';
-    const AFTER_PROCESSING_MESSAGE  = 'after_processing';
-
+if (class_exists('Symfony\Contracts\EventDispatcher\Event')) {
     /**
-     * @var AMQPMessage
-     */
-    protected $AMQPMessage;
-
-    /**
-     * @var Consumer
-     */
-    protected $consumer;
-
-    /**
-     * @return AMQPMessage
-     */
-    public function getAMQPMessage()
-    {
-        return $this->AMQPMessage;
-    }
-
-    /**
-     * @param AMQPMessage $AMQPMessage
+     * Class AMQPEvent
      *
-     * @return AMQPEvent
+     * @package OldSound\RabbitMqBundle\Event
+     * @codeCoverageIgnore
      */
-    public function setAMQPMessage(AMQPMessage $AMQPMessage)
+    class AMQPEvent extends ContractsEvent
     {
-        $this->AMQPMessage = $AMQPMessage;
+        const ON_CONSUME = 'on_consume';
+        const ON_IDLE = 'on_idle';
+        const BEFORE_PROCESSING_MESSAGE = 'before_processing';
+        const AFTER_PROCESSING_MESSAGE = 'after_processing';
 
-        return $this;
+        /**
+         * @var AMQPMessage
+         */
+        protected $AMQPMessage;
+
+        /**
+         * @var Consumer
+         */
+        protected $consumer;
+
+        /**
+         * @return AMQPMessage
+         */
+        public function getAMQPMessage()
+        {
+            return $this->AMQPMessage;
+        }
+
+        /**
+         * @param AMQPMessage $AMQPMessage
+         *
+         * @return AMQPEvent
+         */
+        public function setAMQPMessage(AMQPMessage $AMQPMessage)
+        {
+            $this->AMQPMessage = $AMQPMessage;
+
+            return $this;
+        }
+
+        /**
+         * @return Consumer
+         */
+        public function getConsumer()
+        {
+            return $this->consumer;
+        }
+
+        /**
+         * @param Consumer $consumer
+         *
+         * @return AMQPEvent
+         */
+        public function setConsumer(Consumer $consumer)
+        {
+            $this->consumer = $consumer;
+
+            return $this;
+        }
     }
-
+} else {
     /**
-     * @return Consumer
-     */
-    public function getConsumer()
-    {
-        return $this->consumer;
-    }
-
-    /**
-     * @param Consumer $consumer
+     * Class AMQPEvent
      *
-     * @return AMQPEvent
+     * @package OldSound\RabbitMqBundle\Event
+     * @codeCoverageIgnore
      */
-    public function setConsumer(Consumer $consumer)
+    class AMQPEvent extends Event
     {
-        $this->consumer = $consumer;
+        const ON_CONSUME                = 'on_consume';
+        const ON_IDLE                   = 'on_idle';
+        const BEFORE_PROCESSING_MESSAGE = 'before_processing';
+        const AFTER_PROCESSING_MESSAGE  = 'after_processing';
 
-        return $this;
+        /**
+         * @var AMQPMessage
+         */
+        protected $AMQPMessage;
+
+        /**
+         * @var Consumer
+         */
+        protected $consumer;
+
+        /**
+         * @return AMQPMessage
+         */
+        public function getAMQPMessage()
+        {
+            return $this->AMQPMessage;
+        }
+
+        /**
+         * @param AMQPMessage $AMQPMessage
+         *
+         * @return AMQPEvent
+         */
+        public function setAMQPMessage(AMQPMessage $AMQPMessage)
+        {
+            $this->AMQPMessage = $AMQPMessage;
+
+            return $this;
+        }
+
+        /**
+         * @return Consumer
+         */
+        public function getConsumer()
+        {
+            return $this->consumer;
+        }
+
+        /**
+         * @param Consumer $consumer
+         *
+         * @return AMQPEvent
+         */
+        public function setConsumer(Consumer $consumer)
+        {
+            $this->consumer = $consumer;
+
+            return $this;
+        }
     }
 }

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -8,6 +8,7 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 abstract class BaseAmqp
 {
@@ -267,11 +268,20 @@ abstract class BaseAmqp
      */
     protected function dispatchEvent($eventName, AMQPEvent $event)
     {
-        if ($this->getEventDispatcher()) {
-            $this->getEventDispatcher()->dispatch(
-                $eventName,
-                $event
-            );
+        $eventDispatcher = $this->getEventDispatcher();
+
+        if ($eventDispatcher) {
+            if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+                $eventDispatcher->dispatch(
+                    $event,
+                    $eventName
+                );
+            } else {
+                $eventDispatcher->dispatch(
+                    $eventName,
+                    $event
+                );
+            }
         }
     }
 

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -8,7 +8,7 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 
 abstract class BaseAmqp
 {
@@ -271,7 +271,7 @@ abstract class BaseAmqp
         $eventDispatcher = $this->getEventDispatcher();
 
         if ($eventDispatcher) {
-            if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            if ($eventDispatcher instanceof PsrEventDispatcherInterface) {
                 $eventDispatcher->dispatch(
                     $event,
                     $eventName

--- a/Tests/RabbitMq/BaseAmqpTest.php
+++ b/Tests/RabbitMq/BaseAmqpTest.php
@@ -6,6 +6,7 @@ use OldSound\RabbitMqBundle\Event\AMQPEvent;
 use OldSound\RabbitMqBundle\RabbitMq\BaseAmqp;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 class BaseAmqpTest extends TestCase
 {
@@ -55,10 +56,17 @@ class BaseAmqpTest extends TestCase
             ->method('getEventDispatcher')
             ->willReturn($eventDispatcher);
 
-        $eventDispatcher->expects($this->once())
-            ->method('dispatch')
-            ->with(AMQPEvent::ON_CONSUME, new AMQPEvent())
-            ->willReturn(true);
+        if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $eventDispatcher->expects($this->once())
+                ->method('dispatch')
+                ->with(new AMQPEvent(), AMQPEvent::ON_CONSUME)
+                ->willReturn(true);
+        } else {
+            $eventDispatcher->expects($this->once())
+                ->method('dispatch')
+                ->with(AMQPEvent::ON_CONSUME, new AMQPEvent())
+                ->willReturn(true);
+        }
         $this->invokeMethod('dispatchEvent', $baseAmqpConsumer, array(AMQPEvent::ON_CONSUME, new AMQPEvent()));
     }
 

--- a/Tests/RabbitMq/BaseAmqpTest.php
+++ b/Tests/RabbitMq/BaseAmqpTest.php
@@ -6,7 +6,7 @@ use OldSound\RabbitMqBundle\Event\AMQPEvent;
 use OldSound\RabbitMqBundle\RabbitMq\BaseAmqp;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PHPUnit\Framework\TestCase;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 
 class BaseAmqpTest extends TestCase
 {
@@ -56,7 +56,7 @@ class BaseAmqpTest extends TestCase
             ->method('getEventDispatcher')
             ->willReturn($eventDispatcher);
 
-        if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+        if ($eventDispatcher instanceof PsrEventDispatcherInterface) {
             $eventDispatcher->expects($this->once())
                 ->method('dispatch')
                 ->with(new AMQPEvent(), AMQPEvent::ON_CONSUME)

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -71,7 +71,7 @@ class ConsumerTest extends TestCase
             $amqpChannel->expects($this->never())->method('basic_nack');
         }
 
-        if (interface_exists(PsrEventDispatcherInterface::class)) {
+        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
             $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
         } else {
             $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
@@ -182,7 +182,7 @@ class ConsumerTest extends TestCase
             );
 
         // set up event dispatcher
-        if (interface_exists(PsrEventDispatcherInterface::class)) {
+        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
             $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
         } else {
             $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
@@ -267,7 +267,7 @@ class ConsumerTest extends TestCase
             ->willThrowException(new AMQPTimeoutException());
 
         // set up event dispatcher
-        if (interface_exists(PsrEventDispatcherInterface::class)) {
+        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
             $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
         } else {
             $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -76,10 +76,12 @@ class ConsumerTest extends TestCase
         } else {
             $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
         }
+        echo '$eventDispatcherClassName = ' . $eventDispatcherClassName;
         $eventDispatcher = $this->getMockBuilder($eventDispatcherClassName)->getMock();
         $consumer->setEventDispatcher($eventDispatcher);
 
         if ($eventDispatcher instanceof ContactsEventDispatcherInterface) {
+            echo '*** NEW DispatcherInterface';
             $eventDispatcher->expects($this->atLeastOnce())
                 ->method('dispatch')
                 ->withConsecutive(
@@ -88,6 +90,7 @@ class ConsumerTest extends TestCase
                 )
                 ->willReturn(true);
         } else {
+            echo '*** OLD DispatcherInterface';
             $eventDispatcher->expects($this->atLeastOnce())
                 ->method('dispatch')
                 ->withConsecutive(

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -71,17 +71,14 @@ class ConsumerTest extends TestCase
             $amqpChannel->expects($this->never())->method('basic_nack');
         }
 
-        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
+        if (interface_exists(PsrEventDispatcherInterface::class)) {
             $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
         } else {
             $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
         }
-        echo '$eventDispatcherClassName = ' . $eventDispatcherClassName;
         $eventDispatcher = $this->getMockBuilder($eventDispatcherClassName)->getMock();
         $consumer->setEventDispatcher($eventDispatcher);
-
         if ($eventDispatcher instanceof ContactsEventDispatcherInterface) {
-            echo '*** NEW DispatcherInterface';
             $eventDispatcher->expects($this->atLeastOnce())
                 ->method('dispatch')
                 ->withConsecutive(
@@ -90,7 +87,6 @@ class ConsumerTest extends TestCase
                 )
                 ->willReturn(true);
         } else {
-            echo '*** OLD DispatcherInterface';
             $eventDispatcher->expects($this->atLeastOnce())
                 ->method('dispatch')
                 ->withConsecutive(
@@ -186,7 +182,7 @@ class ConsumerTest extends TestCase
             );
 
         // set up event dispatcher
-        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
+        if (interface_exists(PsrEventDispatcherInterface::class)) {
             $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
         } else {
             $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
@@ -271,7 +267,7 @@ class ConsumerTest extends TestCase
             ->willThrowException(new AMQPTimeoutException());
 
         // set up event dispatcher
-        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
+        if (interface_exists(PsrEventDispatcherInterface::class)) {
             $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
         } else {
             $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -70,8 +70,13 @@ class ConsumerTest extends TestCase
             $amqpChannel->expects($this->never())->method('basic_ack');
             $amqpChannel->expects($this->never())->method('basic_nack');
         }
-        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
-            ->getMock();
+
+        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
+            $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
+        } else {
+            $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
+        }
+        $eventDispatcher = $this->getMockBuilder($eventDispatcherClassName)->getMock();
         $consumer->setEventDispatcher($eventDispatcher);
 
         if ($eventDispatcher instanceof ContactsEventDispatcherInterface) {
@@ -178,7 +183,12 @@ class ConsumerTest extends TestCase
             );
 
         // set up event dispatcher
-        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
+            $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
+        } else {
+            $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
+        }
+        $eventDispatcher = $this->getMockBuilder($eventDispatcherClassName)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -258,7 +268,12 @@ class ConsumerTest extends TestCase
             ->willThrowException(new AMQPTimeoutException());
 
         // set up event dispatcher
-        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+        if (interface_exists('Psr\EventDispatcher\EventDispatcherInterface')) {
+            $eventDispatcherClassName = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
+        } else {
+            $eventDispatcherClassName = 'Symfony\Component\EventDispatcher\EventDispatcherInterface';
+        }
+        $eventDispatcher = $this->getMockBuilder($eventDispatcherClassName)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
Removes deprecation warnings regarding Symfony 4.3:

- The "OldSound\RabbitMqBundle\Event\AMQPEvent" class extends "Symfony\Component\EventDispatcher\Event" that is deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead.
-  Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.
- Adapt changes to test suite.
