### PR TITLE
Hotfix/fix symfony dispatch exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 7.2
-  - 7.1
   - 7.0
   - 5.6
   - 5.6
@@ -34,9 +32,13 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION=3.0.*
     - php: 7.1
-      env: DEPENDENCIES=beta
+      env: SYMFONY_VERSION=3.0.*
     - php: 7.2
-      env: DEPENDENCIES=beta
+      env: SYMFONY_VERSION=3.0.*
+    - php: 7.3
+      env: SYMFONY_VERSION=3.0.*
+    - php: 7.1
+      env: SYMFONY_VERSION=^4.0
 
   allow_failures:
     - php: nightly
@@ -52,7 +54,7 @@ before_install:
   - if [ "$COMPOSER_FLAGS" != "" ]; then composer update --prefer-dist --no-interaction --no-scripts $COMPOSER_FLAGS; fi;
 
 install:
-  - composer install --prefer-dist
-
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install --prefer-dist --no-interaction
+  
 script:
   - vendor/bin/phpunit

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $tree = new TreeBuilder($this->name);
-        $rootNode = \method_exists(TreeBuilder::class, 'getRootNode') ? $tree->getRootNode() : $tree->root($this->name);
+        $rootNode = \method_exists('Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode') ? $tree->getRootNode() : $tree->root($this->name);
 
         $rootNode
             ->children()

--- a/Event/AMQPEvent.php
+++ b/Event/AMQPEvent.php
@@ -12,7 +12,7 @@ use Symfony\Component\EventDispatcher\Event;
  * @package OldSound\RabbitMqBundle\Event
  * @codeCoverageIgnore
  */
-class AMQPEvent extends Event
+class AMQPEvent extends AbstractAMQPEvent
 {
     const ON_CONSUME                = 'on_consume';
     const ON_IDLE                   = 'on_idle';

--- a/Event/AbstractAMQPEvent.php
+++ b/Event/AbstractAMQPEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event as ContractsBaseEvent;
+use Symfony\Component\EventDispatcher\Event as BaseEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+if (is_subclass_of('EventDispatcher', 'EventDispatcherInterface')) {
+
+    abstract class AbstractAMQPEvent extends ContractsBaseEvent
+    {
+
+    }
+} else {
+
+    abstract class AbstractAMQPEvent extends BaseEvent
+    {
+
+    }
+}

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -269,8 +269,8 @@ abstract class BaseAmqp
     {
         if ($this->getEventDispatcher()) {
             $this->getEventDispatcher()->dispatch(
-                $eventName,
-                $event
+                $event,
+                $eventName
             );
         }
     }

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -8,6 +8,7 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 abstract class BaseAmqp
 {
@@ -268,10 +269,17 @@ abstract class BaseAmqp
     protected function dispatchEvent($eventName, AMQPEvent $event)
     {
         if ($this->getEventDispatcher()) {
-            $this->getEventDispatcher()->dispatch(
-                $event,
-                $eventName
-            );
+            if ($this->getEventDispatcher() instanceof ContractsEventDispatcherInterface) {
+                $this->getEventDispatcher()->dispatch(
+                    $event,
+                    $eventName
+                );
+            } else {
+                $this->getEventDispatcher()->dispatch(
+                    $eventName,
+                    $event
+                );
+            }
         }
     }
 

--- a/Tests/DependencyInjection/Fixtures/collector.yml
+++ b/Tests/DependencyInjection/Fixtures/collector.yml
@@ -19,3 +19,7 @@ old_sound_rabbit_mq:
             queue_options:
                 name:       default_queue
             callback:       default.callback
+
+services:
+    default.callback:
+        class: \stdClass

--- a/Tests/DependencyInjection/Fixtures/collector_disabled.yml
+++ b/Tests/DependencyInjection/Fixtures/collector_disabled.yml
@@ -19,3 +19,6 @@ old_sound_rabbit_mq:
             queue_options:
                 name:       default_queue
             callback:       default.callback
+services:
+    default.callback:
+        class: \stdClass

--- a/Tests/DependencyInjection/Fixtures/config_with_enable_logger.yml
+++ b/Tests/DependencyInjection/Fixtures/config_with_enable_logger.yml
@@ -23,3 +23,6 @@ old_sound_rabbit_mq:
 services:
     logger:
         class: \stdClass
+    default.callback:
+        class: \stdClass
+

--- a/Tests/DependencyInjection/Fixtures/exchange_arguments.yml
+++ b/Tests/DependencyInjection/Fixtures/exchange_arguments.yml
@@ -21,3 +21,6 @@ old_sound_rabbit_mq:
             queue_options:
                 name:       foo_queue
             callback:       consumer.callback
+services:
+    consumer.callback:
+        class: \stdClass

--- a/Tests/DependencyInjection/Fixtures/rpc-clients.yml
+++ b/Tests/DependencyInjection/Fixtures/rpc-clients.yml
@@ -7,7 +7,7 @@ old_sound_rabbit_mq:
             user:     foo_user
             password: foo_password
             vhost:    /foo
-
+        default:
     rpc_clients:
         foo_client:
             connection:      foo_connection

--- a/Tests/DependencyInjection/Fixtures/test.yml
+++ b/Tests/DependencyInjection/Fixtures/test.yml
@@ -46,6 +46,9 @@ old_sound_rabbit_mq:
             use_socket: true
 
         default:
+        default2:
+        foo_default:
+        bar_default:
 
     producers:
         foo_producer:
@@ -222,3 +225,34 @@ old_sound_rabbit_mq:
             exchange_options:
                 name: exchange
                 type: topic
+services:
+    foo.callback:
+        class: \stdClass
+    default.callback:
+        class: \stdClass
+    foo.multiple_test1.callback:
+        class: \stdClass
+    foo.multiple_test2.callback:
+        class: \stdClass
+    foo.queues_provider:
+        class: \stdClass
+    foo.dynamic.callback:
+        class: \stdClass
+    foo.dynamic.provider:
+        class: \stdClass
+    bar.dynamic.provider:
+        class: \stdClass
+    bar.dynamic.callback:
+        class: \stdClass
+    foo_anon.callback:
+        class: \stdClass
+    default_anon.callback:
+        class: \stdClass
+    foo_server.callback:
+        class: \stdClass
+    default_server.callback:
+        class: \stdClass
+    server_with_queue_options.callback:
+        class: \stdClass
+    server_with_exchange_options.callback:
+        class: \stdClass

--- a/Tests/RabbitMq/BaseAmqpTest.php
+++ b/Tests/RabbitMq/BaseAmqpTest.php
@@ -57,7 +57,7 @@ class BaseAmqpTest extends TestCase
 
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(AMQPEvent::ON_CONSUME, new AMQPEvent())
+            ->with(new AMQPEvent(), AMQPEvent::ON_CONSUME)
             ->willReturn(true);
         $this->invokeMethod('dispatchEvent', $baseAmqpConsumer, array(AMQPEvent::ON_CONSUME, new AMQPEvent()));
     }

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -83,7 +83,7 @@ class ConsumerTest extends TestCase
         $consumer->setEventDispatcher($eventDispatcher);
 
         if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $eventDispatcher->expects($this->once())
+            $eventDispatcher->expects($this->atLeastOnce())
                 ->method('dispatch')
                 ->withConsecutive(
                     array(new BeforeProcessingMessageEvent($consumer, $amqpMessage), BeforeProcessingMessageEvent::NAME),
@@ -91,7 +91,7 @@ class ConsumerTest extends TestCase
                 )
                 ->willReturn(true);
         } else {
-            $eventDispatcher->expects($this->once())
+            $eventDispatcher->expects($this->atLeastOnce())
                 ->method('dispatch')
                 ->withConsecutive(
                     array(BeforeProcessingMessageEvent::NAME, new BeforeProcessingMessageEvent($consumer, $amqpMessage)),
@@ -196,12 +196,12 @@ class ConsumerTest extends TestCase
         }
 
         if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $eventDispatcher->expects($this->once())
+            $eventDispatcher->expects($this->exactly(count($consumerCallBacks))
                 ->method('dispatch')
                 ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'), OnConsumeEvent::NAME)
                 ->willReturn(true);
         } else {
-            $eventDispatcher->expects($this->once())
+            $eventDispatcher->expects($this->exactly(count($consumerCallBacks))
                 ->method('dispatch')
                 ->with(OnConsumeEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'))
                 ->willReturn(true);
@@ -281,7 +281,7 @@ class ConsumerTest extends TestCase
         }
 
         if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $eventDispatcher->expects($this->once())
+            $eventDispatcher->expects($this->at(1))
                 ->method('dispatch')
                 ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'), OnIdleEvent::NAME)
                 ->willReturnCallback(function(OnIdleEvent $event, $eventName) {

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -196,12 +196,12 @@ class ConsumerTest extends TestCase
         }
 
         if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
-            $eventDispatcher->expects($this->exactly(count($consumerCallBacks))
+            $eventDispatcher->expects($this->exactly(count($consumerCallBacks)))
                 ->method('dispatch')
                 ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'), OnConsumeEvent::NAME)
                 ->willReturn(true);
         } else {
-            $eventDispatcher->expects($this->exactly(count($consumerCallBacks))
+            $eventDispatcher->expects($this->exactly(count($consumerCallBacks)))
                 ->method('dispatch')
                 ->with(OnConsumeEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'))
                 ->willReturn(true);

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -11,6 +11,7 @@ use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 class ConsumerTest extends TestCase
 {
@@ -70,17 +71,34 @@ class ConsumerTest extends TestCase
             $amqpChannel->expects($this->never())->method('basic_ack');
             $amqpChannel->expects($this->never())->method('basic_nack');
         }
-        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
-            ->getMock();
+        if (is_subclass_of('AMQPEvent', 'ContractsBaseEvent')) {
+            $eventDispatcher = $this->getMockBuilder('Symfony\Contracts\EventDispatcher\EventDispatcherInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
+        } else {
+            $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
         $consumer->setEventDispatcher($eventDispatcher);
 
-        $eventDispatcher->expects($this->atLeastOnce())
-            ->method('dispatch')
-            ->withConsecutive(
-                array(new BeforeProcessingMessageEvent($consumer, $amqpMessage), BeforeProcessingMessageEvent::NAME),
-                array(new AfterProcessingMessageEvent($consumer, $amqpMessage), AfterProcessingMessageEvent::NAME)
-            )
-            ->willReturn(true);
+        if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $eventDispatcher->expects($this->once())
+                ->method('dispatch')
+                ->withConsecutive(
+                    array(new BeforeProcessingMessageEvent($consumer, $amqpMessage), BeforeProcessingMessageEvent::NAME),
+                    array(new AfterProcessingMessageEvent($consumer, $amqpMessage), AfterProcessingMessageEvent::NAME)
+                )
+                ->willReturn(true);
+        } else {
+            $eventDispatcher->expects($this->once())
+                ->method('dispatch')
+                ->withConsecutive(
+                    array(BeforeProcessingMessageEvent::NAME, new BeforeProcessingMessageEvent($consumer, $amqpMessage)),
+                    array(AfterProcessingMessageEvent::NAME, new AfterProcessingMessageEvent($consumer, $amqpMessage))
+                )
+                ->willReturn(true);
+        }
         $consumer->processMessage($amqpMessage);
     }
 
@@ -167,15 +185,27 @@ class ConsumerTest extends TestCase
                     })
             );
 
-        // set up event dispatcher
-        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
-            ->disableOriginalConstructor()
-            ->getMock();
+        if (is_subclass_of('AMQPEvent', 'ContractsBaseEvent')) {
+            $eventDispatcher = $this->getMockBuilder('Symfony\Contracts\EventDispatcher\EventDispatcherInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
+        } else {
+            $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
 
-        $eventDispatcher->expects($this->exactly(count($consumerCallBacks)))
-            ->method('dispatch')
-            ->with(OnConsumeEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'))
-            ->willReturn(true);
+        if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $eventDispatcher->expects($this->once())
+                ->method('dispatch')
+                ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'), OnConsumeEvent::NAME)
+                ->willReturn(true);
+        } else {
+            $eventDispatcher->expects($this->once())
+                ->method('dispatch')
+                ->with(OnConsumeEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnConsumeEvent'))
+                ->willReturn(true);
+        }
 
         $consumer->setEventDispatcher($eventDispatcher);
         $consumer->consume(1);
@@ -240,23 +270,45 @@ class ConsumerTest extends TestCase
             ->with(null, false, $consumer->getIdleTimeout())
             ->willThrowException(new AMQPTimeoutException());
 
-        // set up event dispatcher
-        $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
-            ->disableOriginalConstructor()
-            ->getMock();
+        if (is_subclass_of('AMQPEvent', 'ContractsBaseEvent')) {
+            $eventDispatcher = $this->getMockBuilder('Symfony\Contracts\EventDispatcher\EventDispatcherInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
+        } else {
+            $eventDispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
 
-        $eventDispatcher->expects($this->at(1))
-            ->method('dispatch')
-            ->with(OnIdleEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'))
-            ->willReturnCallback(function($eventName, OnIdleEvent $event) {
-                $event->setForceStop(false);
-            });
-        $eventDispatcher->expects($this->at(3))
-            ->method('dispatch')
-            ->with(OnIdleEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'))
-            ->willReturn(function($eventName, OnIdleEvent $event) {
-                $event->setForceStop(true);
-        });
+        if ($eventDispatcher instanceof ContractsEventDispatcherInterface) {
+            $eventDispatcher->expects($this->once())
+                ->method('dispatch')
+                ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'), OnIdleEvent::NAME)
+                ->willReturnCallback(function(OnIdleEvent $event, $eventName) {
+                    $event->setForceStop(false);
+                });
+
+            $eventDispatcher->expects($this->at(3))
+                ->method('dispatch')
+                ->with($this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'), OnIdleEvent::NAME)
+                ->willReturn(function(OnIdleEvent $event, $eventName) {
+                    $event->setForceStop(true);
+                });
+        } else {
+            $eventDispatcher->expects($this->at(1))
+                ->method('dispatch')
+                ->with(OnIdleEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'))
+                ->willReturnCallback(function($eventName, OnIdleEvent $event) {
+                    $event->setForceStop(false);
+                });
+
+            $eventDispatcher->expects($this->at(3))
+                ->method('dispatch')
+                ->with(OnIdleEvent::NAME, $this->isInstanceOf('OldSound\RabbitMqBundle\Event\OnIdleEvent'))
+                ->willReturn(function($eventName, OnIdleEvent $event) {
+                    $event->setForceStop(true);
+                });
+        }
 
         $consumer->setEventDispatcher($eventDispatcher);
 

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -77,8 +77,8 @@ class ConsumerTest extends TestCase
         $eventDispatcher->expects($this->atLeastOnce())
             ->method('dispatch')
             ->withConsecutive(
-                array(BeforeProcessingMessageEvent::NAME, new BeforeProcessingMessageEvent($consumer, $amqpMessage)),
-                array(AfterProcessingMessageEvent::NAME, new AfterProcessingMessageEvent($consumer, $amqpMessage))
+                array(new BeforeProcessingMessageEvent($consumer, $amqpMessage), BeforeProcessingMessageEvent::NAME),
+                array(new AfterProcessingMessageEvent($consumer, $amqpMessage), AfterProcessingMessageEvent::NAME)
             )
             ->willReturn(true);
         $consumer->processMessage($amqpMessage);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "stefanovik/rabbitmq-bundle",
+    "name": "php-amqplib/rabbitmq-bundle",
     "type": "symfony-bundle",
     "description": "Integrates php-amqplib with Symfony & RabbitMq. Formerly oldsound/rabbitmq-bundle.",
     "keywords": ["symfony", "symfony2", "symfony3", "symfony4", "rabbitmq", "message", "queue", "amqp"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "php-amqplib/rabbitmq-bundle",
+    "name": "stefanovik/rabbitmq-bundle",
     "type": "symfony-bundle",
     "description": "Integrates php-amqplib with Symfony & RabbitMq. Formerly oldsound/rabbitmq-bundle.",
     "keywords": ["symfony", "symfony2", "symfony3", "symfony4", "rabbitmq", "message", "queue", "amqp"],


### PR DESCRIPTION
Due to the fact that symfony 4.3 EventDispatcherInterface and Event  have been moved to a new namespace i've done this pull request only to tread the EventDispatcher deprecated messages. As an inspiration for this i've thrown a look at how https://github.com/8p/EightPointsGuzzleBundle/pull/265/files was done. 