### PR TITLE
Require php-amqplib ^2.12.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/config":               "^4.3|^5.0",
         "symfony/yaml":                 "^4.3|^5.0",
         "symfony/console":              "^4.3|^5.0",
-        "php-amqplib/php-amqplib":      "^2.12|^3.0",
+        "php-amqplib/php-amqplib":      "^2.12.2|^3.0",
         "psr/log":                      "^1.0",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4|^5.0"


### PR DESCRIPTION
This version is the only one that disallows installation on PHP 8.0. While 2.12.0 and 2.12.1 are installable on php: >=5.6.3.

In SimpleBus we test our dependencies with `lowest` and therefore this fails on PHP 8.0. 

See PR with failing tests https://github.com/SimpleBus/SimpleBus/pull/115

Of course, we could add a conflict, but I believe this should be done here.