### PR TITLE
Group consumer

### DIFF
--- a/Command/GroupConsumerCommand.php
+++ b/Command/GroupConsumerCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Command;
+
+class GroupConsumerCommand extends BaseConsumerCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('rabbitmq:group:consumer')
+            ->setDescription('Synchronous execute grouped consumers')
+        ;
+    }
+
+    protected function getConsumerService()
+    {
+        return 'old_sound_rabbit_mq.%s_group';
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -49,6 +49,7 @@ class Configuration implements ConfigurationInterface
         $this->addMultipleConsumers($rootNode);
         $this->addDynamicConsumers($rootNode);
         $this->addBatchConsumers($rootNode);
+        $this->addGroupConsumers($rootNode);
         $this->addAnonConsumers($rootNode);
         $this->addRpcClients($rootNode);
         $this->addRpcServers($rootNode);
@@ -152,6 +153,10 @@ class Configuration implements ConfigurationInterface
                         ->append($this->getQueueConfiguration())
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
+                            ->arrayNode('groups')->defaultValue(array('default'))
+                            ->prototype('scalar')
+                            ->end()
+                            ->end()
                             ->scalarNode('callback')->isRequired()->end()
                             ->scalarNode('idle_timeout')->end()
                             ->scalarNode('idle_timeout_exit_code')->end()
@@ -192,6 +197,10 @@ class Configuration implements ConfigurationInterface
                     ->append($this->getExchangeConfiguration())
                     ->children()
                         ->scalarNode('connection')->defaultValue('default')->end()
+                        ->arrayNode('groups')->defaultValue(array('default'))
+                        ->prototype('scalar')
+                        ->end()
+                        ->end()
                         ->scalarNode('idle_timeout')->end()
                         ->scalarNode('idle_timeout_exit_code')->end()
                         ->scalarNode('timeout_wait')->end()
@@ -232,6 +241,10 @@ class Configuration implements ConfigurationInterface
                         ->append($this->getExchangeConfiguration())
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
+                            ->arrayNode('groups')->defaultValue(array('default'))
+                            ->prototype('scalar')
+                            ->end()
+                            ->end()
                             ->scalarNode('callback')->isRequired()->end()
                             ->scalarNode('idle_timeout')->end()
                             ->scalarNode('idle_timeout_exit_code')->end()
@@ -278,6 +291,10 @@ class Configuration implements ConfigurationInterface
                         ->append($this->getQueueConfiguration())
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
+                            ->arrayNode('groups')->defaultValue(array('default'))
+                            ->prototype('scalar')
+                            ->end()
+                            ->end()
                             ->scalarNode('callback')->isRequired()->end()
                             ->scalarNode('idle_timeout')->end()
                             ->scalarNode('timeout_wait')->defaultValue(3)->end()
@@ -304,6 +321,40 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
     }
+    
+    protected function addGroupConsumers(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('group_consumers')
+                    ->canBeUnset()
+                    ->useAttributeAsKey('key')
+                    ->prototype('array')
+                        ->children()
+                        ->scalarNode('connection')->defaultValue('default')->end()
+                        ->scalarNode('idle_timeout')->end()
+                        ->scalarNode('idle_timeout_exit_code')->end()
+                        ->scalarNode('timeout_wait')->end()
+                        ->arrayNode('graceful_max_execution')
+                            ->canBeUnset()
+                            ->children()
+                            ->integerNode('timeout')->end()
+                            ->integerNode('exit_code')->defaultValue(0)->end()
+                            ->end()
+                        ->end()
+                        ->scalarNode('auto_setup_fabric')->defaultTrue()->end()
+                        ->arrayNode('qos_options')
+                            ->canBeUnset()
+                            ->children()
+                                ->scalarNode('prefetch_size')->defaultValue(0)->end()
+                                ->scalarNode('prefetch_count')->defaultValue(0)->end()
+                                ->booleanNode('global')->defaultFalse()->end()
+                            ->end()
+                        ->end()
+                        ->scalarNode('enable_logger')->defaultFalse()->end()
+                ->end()
+            ->end();
+    }
 
     protected function addAnonConsumers(ArrayNodeDefinition $node)
     {
@@ -317,6 +368,10 @@ class Configuration implements ConfigurationInterface
                         ->append($this->getExchangeConfiguration())
                         ->children()
                             ->scalarNode('connection')->defaultValue('default')->end()
+                            ->arrayNode('groups')->defaultValue(array('default'))
+                            ->prototype('scalar')
+                            ->end()
+                            ->end()
                             ->scalarNode('callback')->isRequired()->end()
                         ->end()
                     ->end()

--- a/README.md
+++ b/README.md
@@ -916,6 +916,46 @@ Important: BatchConsumers will not have the -m|messages option available
 Important: BatchConsumers can also have the -b|batches option available if you want to only consume a specific number of batches and then stop the consumer.
 ! Give the number of the batches only if you want the consumer to stop after those batch messages were consumed.! 
 
+### Group Consumer Command ###
+
+Consume multiple queues by one worker command for reduce complexity and simplify debugging.
+A lot of running php commands can consume significant memory size and would be not convinient in development and testing environment which no need parallel executation.
+
+You can consume all defined queues with default group
+```bash
+    $ ./bin/console rabbitmq:group:consumer default
+```
+
+Specify group and run together with one worker.
+```yaml
+consumers:
+    deposit:
+        connection:             default
+        exchange_options:       {name: 'deposit', type: direct}
+        queue_options:          {name: 'deposit'}
+        ...
+        groups:                 ['payment'] # without specify will be equals ['default']
+
+    withdraw:
+        connection:             default
+        exchange_options:       {name: 'withdraw', type: direct}
+        ...
+        groups:                 ['payment']
+
+group_consumer:
+    default:
+        #connection:             default
+        qos_options:
+            prefetch_size:      0
+            prefetch_count:     10
+    payment:
+        connection:             payment_connection
+        timeout_wait:       30
+```
+```bash
+    $ ./bin/console rabbitmq:group:consumer payment
+```
+
 ### STDIN Producer ###
 
 There's a Command that reads data from STDIN and publishes it to a RabbitMQ queue. To use it first you have to configure a `producer` service in your configuration file like this:

--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -63,7 +63,7 @@ abstract class BaseConsumer extends BaseAmqp implements DequeuerInterface
         $this->getChannel()->basic_cancel($this->getConsumerTag(), false, true);
     }
 
-    protected function setupConsumer()
+    public function setupConsumer()
     {
         if ($this->autoSetupFabric) {
             $this->setupFabric();

--- a/RabbitMq/BatchConsumer.php
+++ b/RabbitMq/BatchConsumer.php
@@ -348,7 +348,7 @@ class BatchConsumer extends BaseAmqp implements DequeuerInterface
     /**
      * @return  void
      */
-    protected function setupConsumer()
+    public function setupConsumer()
     {
         if ($this->autoSetupFabric) {
             $this->setupFabric();

--- a/RabbitMq/DynamicConsumer.php
+++ b/RabbitMq/DynamicConsumer.php
@@ -39,7 +39,7 @@ class DynamicConsumer extends Consumer{
     }
 
 
-    protected function setupConsumer()
+    public function setupConsumer()
     {   
         $this->mergeQueueOptions();
         parent::setupConsumer();

--- a/RabbitMq/GroupConsumer.php
+++ b/RabbitMq/GroupConsumer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\RabbitMq;
+
+use PhpAmqpLib\Connection\AbstractConnection;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+
+class GroupConsumer extends Consumer
+{
+    /** @var iterable|Consumer[] */
+    protected $consumers = array();
+
+    public function addConsumers(iterable $consumers)
+    {
+        foreach ($consumers as $consumer) {
+            $consumer->setChannel($this->ch);
+            $consumer->setConsumerTag(sprintf("PHPPROCESS_%s_%s_%s", gethostname(), getmypid(), count($this->consumers)));
+            $this->consumers[] = $consumer;
+        }
+    }
+
+    public function setupConsumer()
+    {
+        foreach ($this->consumers as $consumer) {
+            $consumer->setupConsumer();
+        }
+    }
+
+    public function stopConsuming()
+    {
+        foreach ($this->consumers as $consumer) {
+            $consumer->stopConsuming();
+        }
+    }
+
+    public function purge()
+    {
+        foreach ($this->consumers as $consumer) {
+            $consumer->purge();
+        }
+    }
+
+    public function delete()
+    {
+        foreach ($this->consumers as $consumer) {
+            $consumer->delete();
+        }
+    }
+
+    public function disableAutoSetupFabric()
+    {
+        foreach ($this->consumers as $consumer) {
+            $consumer->disableAutoSetupFabric();
+        }
+    }
+}

--- a/RabbitMq/MultipleConsumer.php
+++ b/RabbitMq/MultipleConsumer.php
@@ -52,7 +52,7 @@ class MultipleConsumer extends Consumer
         $this->context = $context;
     }
 
-    protected function setupConsumer()
+    public function setupConsumer()
     {
         $this->mergeQueues();
 

--- a/Resources/config/rabbitmq.xml
+++ b/Resources/config/rabbitmq.xml
@@ -13,6 +13,7 @@
         <parameter key="old_sound_rabbit_mq.producer.class">OldSound\RabbitMqBundle\RabbitMq\Producer</parameter>
         <parameter key="old_sound_rabbit_mq.consumer.class">OldSound\RabbitMqBundle\RabbitMq\Consumer</parameter>
         <parameter key="old_sound_rabbit_mq.multi_consumer.class">OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer</parameter>
+        <parameter key="old_sound_rabbit_mq.group_consumer.class">OldSound\RabbitMqBundle\RabbitMq\GroupConsumer</parameter>
         <parameter key="old_sound_rabbit_mq.dynamic_consumer.class">OldSound\RabbitMqBundle\RabbitMq\DynamicConsumer</parameter>
         <parameter key="old_sound_rabbit_mq.batch_consumer.class">OldSound\RabbitMqBundle\RabbitMq\BatchConsumer</parameter>
         <parameter key="old_sound_rabbit_mq.anon_consumer.class">OldSound\RabbitMqBundle\RabbitMq\AnonConsumer</parameter>
@@ -38,6 +39,10 @@
 
         <service id="old_sound_rabbit_mq.batch_consumer_command" class="OldSound\RabbitMqBundle\Command\BatchConsumerCommand">
             <tag name="console.command" command="rabbitmq:batch:consumer" />
+        </service>
+
+        <service id="old_sound_rabbit_mq.group_consumer_command" class="OldSound\RabbitMqBundle\Command\GroupConsumerCommand">
+            <tag name="console.command" command="rabbitmq:group:consumer" />
         </service>
 
         <service id="old_sound_rabbit_mq.consumer_command" class="OldSound\RabbitMqBundle\Command\ConsumerCommand">

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -812,6 +812,7 @@ class OldSoundRabbitMqExtensionTest extends TestCase
         $this->assertEquals(array(
                 new Reference('old_sound_rabbit_mq.channel.default_producer'),
                 new Reference('old_sound_rabbit_mq.channel.default_consumer'),
+                new Reference('old_sound_rabbit_mq.channel.default_group_consumer'),
             ),
             $definition->getArgument(0)
         );

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     }],
     "require": {
         "php":                          "^7.1|^8.0",
-
         "symfony/dependency-injection": "^4.3|^5.0",
         "symfony/event-dispatcher":     "^4.3|^5.0",
         "symfony/config":               "^4.3|^5.0",


### PR DESCRIPTION
Consume multiple queues by one worker command for reduce complexity and simplify debugging.
A lot of running php commands can consume significant memory size and would be not convinient in development and testing environment which no need parallel executation.