### PR TITLE
Do not use internal and deprecated library variable

### DIFF
--- a/RabbitMq/BaseConsumer.php
+++ b/RabbitMq/BaseConsumer.php
@@ -47,7 +47,7 @@ abstract class BaseConsumer extends BaseAmqp implements DequeuerInterface
 
         $this->setupConsumer();
 
-        while (count($this->getChannel()->callbacks)) {
+        while ($this->getChannel()->is_consuming()) {
             $this->getChannel()->wait();
         }
     }

--- a/RabbitMq/BatchConsumer.php
+++ b/RabbitMq/BatchConsumer.php
@@ -112,7 +112,7 @@ class BatchConsumer extends BaseAmqp implements DequeuerInterface
 
         $this->setupConsumer();
 
-        while (count($this->getChannel()->callbacks)) {
+        while ($this->getChannel()->is_consuming()) {
             if ($this->isCompleteBatch()) {
                 $this->batchConsume();
             }

--- a/RabbitMq/Consumer.php
+++ b/RabbitMq/Consumer.php
@@ -75,7 +75,7 @@ class Consumer extends BaseConsumer
         $this->setupConsumer();
 
         $this->setLastActivityDateTime(new \DateTime());
-        while (count($this->getChannel()->callbacks)) {
+        while ($this->getChannel()->is_consuming()) {
             $this->dispatchEvent(OnConsumeEvent::NAME, new OnConsumeEvent($this));
             $this->maybeStopConsumer();
 


### PR DESCRIPTION
Replace internal library variable AMQPChannel->callbacks with AMQPChannel->is_consuming().