### PR TITLE
Fixed signature of ConsumerInterface::execute

### DIFF
--- a/RabbitMq/ConsumerInterface.php
+++ b/RabbitMq/ConsumerInterface.php
@@ -33,7 +33,7 @@ interface ConsumerInterface
 
     /**
      * @param AMQPMessage $msg The message
-     * @return int One of ConsumerInterface::MSG_* constants according to callback outcome.
+     * @return int|bool One of ConsumerInterface::MSG_* constants according to callback outcome, or false otherwise.
      */
     public function execute(AMQPMessage $msg);
 }


### PR DESCRIPTION
According to the docs, `ConsumerInterface::execute` can return false:

```
            // If your image upload failed due to a temporary error you can return false
            // from your callback so the message will be rejected by the consumer and
            // requeued by RabbitMQ.
            // Any other value not equal to false will acknowledge the message and remove it
            // from the queue
```

Hence the signature needs to be updated, otherwise some static analysis tools will show an error.