### PR TITLE
Producer default routing key

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -124,6 +124,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('class')->defaultValue('%old_sound_rabbit_mq.producer.class%')->end()
                             ->scalarNode('enable_logger')->defaultFalse()->end()
                             ->scalarNode('service_alias')->defaultValue(null)->end()
+                            ->scalarNode('default_routing_key')->defaultValue('')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -185,6 +185,8 @@ class OldSoundRabbitMqExtension extends Extension
                         ->registerAliasForArgument($producerServiceName, $producer['class'], $argName)
                         ->setPublic(false);
                 }
+
+                $definition->addMethodCall('setDefaultRoutingKey', $producer['default_routing_key']);
             }
         } else {
             foreach ($this->config['producers'] as $key => $producer) {

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -186,7 +186,7 @@ class OldSoundRabbitMqExtension extends Extension
                         ->setPublic(false);
                 }
 
-                $definition->addMethodCall('setDefaultRoutingKey', $producer['default_routing_key']);
+                $definition->addMethodCall('setDefaultRoutingKey', array($producer['default_routing_key']));
             }
         } else {
             foreach ($this->config['producers'] as $key => $producer) {

--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -12,6 +12,7 @@ class Producer extends BaseAmqp implements ProducerInterface
 {
     protected $contentType = 'text/plain';
     protected $deliveryMode = 2;
+    protected $defaultRoutingKey = '';
 
     public function setContentType($contentType)
     {
@@ -23,6 +24,13 @@ class Producer extends BaseAmqp implements ProducerInterface
     public function setDeliveryMode($deliveryMode)
     {
         $this->deliveryMode = $deliveryMode;
+
+        return $this;
+    }
+
+    public function setDefaultRoutingKey($defaultRoutingKey)
+    {
+        $this->defaultRoutingKey = $defaultRoutingKey;
 
         return $this;
     }
@@ -40,7 +48,7 @@ class Producer extends BaseAmqp implements ProducerInterface
      * @param array $additionalProperties
      * @param array $headers
      */
-    public function publish($msgBody, $routingKey = '', $additionalProperties = array(), array $headers = null)
+    public function publish($msgBody, $routingKey = null, $additionalProperties = array(), array $headers = null)
     {
         if ($this->autoSetupFabric) {
             $this->setupFabric();
@@ -53,7 +61,8 @@ class Producer extends BaseAmqp implements ProducerInterface
             $msg->set('application_headers', $headersTable);
         }
 
-        $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string)$routingKey);
+        $real_routingKey = $routingKey != null ? $routingKey : $this->defaultRoutingKey;
+        $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string)$real_routingKey);
         $this->logger->debug('AMQP message published', array(
             'amqp' => array(
                 'body' => $msgBody,

--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -61,7 +61,7 @@ class Producer extends BaseAmqp implements ProducerInterface
             $msg->set('application_headers', $headersTable);
         }
 
-        $real_routingKey = $routingKey != null ? $routingKey : $this->defaultRoutingKey;
+        $real_routingKey = $routingKey !== null ? $routingKey : $this->defaultRoutingKey;
         $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string)$real_routingKey);
         $this->logger->debug('AMQP message published', array(
             'amqp' => array(

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -313,6 +313,10 @@ class OldSoundRabbitMqExtensionTest extends TestCase
                             'declare'     => false,
                         )
                     )
+                ),
+                array(
+                    'setDefaultRoutingKey',
+                    array('')
                 )
             ),
             $definition->getMethodCalls()
@@ -394,6 +398,10 @@ class OldSoundRabbitMqExtensionTest extends TestCase
                             'declare'     => false,
                         )
                     )
+                ),
+                array(
+                    'setDefaultRoutingKey',
+                    array('')
                 )
             ),
             $definition->getMethodCalls()


### PR DESCRIPTION
This is a backwards compatible change to allow optionally specifying a "default_routing_key" in the producer configuration. If the configuration isn't specified, the existing functionality is the unchanged default.

The existing code defaults to the routing key (if not specified in the Producer.publish() method) being hard coded an empty string. With this change, you can specify this default in configuration. I'm using this currently to allow producers to be completely defined in configuration, such that I can call Producer.publish($msg) and the configuration will take care of what the routing key needs to be.