### PR TITLE
Add configuration support for default content_type and delivery_mode in Producers

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -125,6 +125,8 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('enable_logger')->defaultFalse()->end()
                             ->scalarNode('service_alias')->defaultValue(null)->end()
                             ->scalarNode('default_routing_key')->defaultValue('')->end()
+                            ->scalarNode('default_content_type')->defaultValue('text/plain')->end()
+                            ->integerNode('default_delivery_mode')->min(1)->max(2)->defaultValue(2)->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -187,6 +187,8 @@ class OldSoundRabbitMqExtension extends Extension
                 }
 
                 $definition->addMethodCall('setDefaultRoutingKey', array($producer['default_routing_key']));
+                $definition->addMethodCall('setContentType', array($producer['default_content_type']));
+                $definition->addMethodCall('setDeliveryMode', array($producer['default_delivery_mode']));
             }
         } else {
             foreach ($this->config['producers'] as $key => $producer) {

--- a/README.md
+++ b/README.md
@@ -131,9 +131,12 @@ old_sound_rabbit_mq:
             url: 'amqp://guest:password@localhost:5672/vhost?lazy=1&connection_timeout=6'
     producers:
         upload_picture:
-            connection:       default
-            exchange_options: {name: 'upload-picture', type: direct}
-            service_alias:    my_app_service # no alias by default
+            connection:            default
+            exchange_options:      {name: 'upload-picture', type: direct}
+            service_alias:         my_app_service # no alias by default
+            default_routing_key:   'optional.routing.key' # defaults to '' if not set
+            default_content_type:  'content/type' # defaults to 'text/plain'
+            default_delivery_mode: 2 # optional. 1 means non-persistent, 2 means persistent. Defaults to "2".
     consumers:
         upload_picture:
             connection:       default
@@ -284,8 +287,7 @@ As you can see, if in your configuration you have a producer called __upload\_pi
 
 Besides the message itself, the `OldSound\RabbitMqBundle\RabbitMq\Producer#publish()` method also accepts an optional routing key parameter and an optional array of additional properties. The array of additional properties allows you to alter the properties with which an `PhpAmqpLib\Message\AMQPMessage` object gets constructed by default. This way, for example, you can change the application headers.
 
-You can use __setContentType__ and __setDeliveryMode__ methods in order to set the message content type and the message
-delivery mode respectively. Default values are __text/plain__ for content type and __2__ for delivery mode.
+You can use __setContentType__ and __setDeliveryMode__ methods in order to set the message content type and the message delivery mode respectively, overriding any default set in the "producers" config section. If not overriden by either the "producers" configuration or an explicit call to these methods (as per the below example), the default values are __text/plain__ for content type and __2__ for delivery mode.
 
 ```php
 $this->get('old_sound_rabbit_mq.upload_picture_producer')->setContentType('application/json');

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -317,6 +317,14 @@ class OldSoundRabbitMqExtensionTest extends TestCase
                 array(
                     'setDefaultRoutingKey',
                     array('')
+                ),
+                array(
+                    'setContentType',
+                    array('text/plain')
+                ),
+                array(
+                    'setDeliveryMode',
+                    array(2)
                 )
             ),
             $definition->getMethodCalls()
@@ -402,6 +410,14 @@ class OldSoundRabbitMqExtensionTest extends TestCase
                 array(
                     'setDefaultRoutingKey',
                     array('')
+                ),
+                array(
+                    'setContentType',
+                    array('text/plain')
+                ),
+                array(
+                    'setDeliveryMode',
+                    array(2)
                 )
             ),
             $definition->getMethodCalls()


### PR DESCRIPTION
Similar to my last pull request, it is handy to be able to declare defaults for content_type and delivery_mode in the Producer. This PR adds these as configurables, and maintains backward compatibility, with the default values being the existing default values. 

With this PR, the caller has the option of either setting these programmatically (existing functionality) or by configuration. Programmatic setting overrides configuration.