### PR TITLE
move ext-pcntl to suggested packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     }],
     "require": {
         "php":                          "^7.1|^8.0",
-        "ext-pcntl": "*",
 
         "symfony/dependency-injection": "^4.3|^5.0",
         "symfony/event-dispatcher":     "^4.3|^5.0",
@@ -32,6 +31,7 @@
         "emag-tech-labs/rabbitmq-bundle": "self.version"
     },
     "suggest": {
+        "ext-pcntl": "*",
         "symfony/framework-bundle": "To use this lib as a full Symfony Bundle and to use the profiler data collector"
     },
     "extra": {


### PR DESCRIPTION
It's not required by the code itself, though can be used if installed.

re: #650 and https://github.com/php-amqplib/RabbitMqBundle/issues/644#issuecomment-930232137