### PR TITLE
refs #668: initialization overwrite in DeleteCommand

### DIFF
--- a/Command/DeleteCommand.php
+++ b/Command/DeleteCommand.php
@@ -22,6 +22,11 @@ class DeleteCommand extends ConsumerCommand
         $this->setName('rabbitmq:delete');
     }
 
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        // nothing to initialize here as BaseConsumerCommand initializes on option that is not available here
+    }
+
     /**
      * @param InputInterface $input
      * @param OutputInterface $output


### PR DESCRIPTION
Same as in case of #644 Delete command doesn't define option on which BaseConsumerCommand initialization relies.