### PR TITLE
Add Symfony 6 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,51 +4,31 @@ on: [push, pull_request]
 
 jobs:
     test:
-        name: PHP ${{ matrix.php-version }} + Symfony ${{ matrix.symfony-version }}
+        name: "PHP ${{ matrix.php-version }} + Symfony ${{ matrix.symfony-version }}${{ matrix.coverage == 'xdebug' && ' + xdebug' || '' }}"
 
-        runs-on: ubuntu-18.04
-
-        continue-on-error: ${{ matrix.experimental }}
+        runs-on: ubuntu-20.04
 
         strategy:
+            fail-fast: false
             matrix:
-                include:
+                php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                symfony-version: ['4.4', '5.4', '6.0']
+                coverage: ['none']
+                exclude:
                     - php-version: '7.1'
-                      symfony-version: '^4.3'
-                      composer-version: v1
-                      stability: stable
-                      coverage: none
-                      experimental: false
+                      symfony-version: '6.0'
+                    - php-version: '7.1'
+                      symfony-version: '5.4'
                     - php-version: '7.2'
-                      symfony-version: '^4.3'
-                      composer-version: v1
-                      stability: stable
-                      coverage: none
-                      experimental: false
-                    - php-version: '7.2'
-                      symfony-version: '^5.0'
-                      composer-version: v1
-                      stability: stable
-                      coverage: none
-                      experimental: false
+                      symfony-version: '6.0'
                     - php-version: '7.3'
-                      symfony-version: '^5.0'
-                      composer-version: v1
-                      stability: stable
-                      coverage: none
-                      experimental: false
+                      symfony-version: '6.0'
                     - php-version: '7.4'
-                      symfony-version: '^5.0'
-                      composer-version: v2
-                      stability: stable
-                      coverage: xdebug
-                      experimental: false
+                      symfony-version: '6.0'
+                include:
                     - php-version: '8.0'
-                      symfony-version: '^5.0'
-                      composer-version: v2
-                      stability: RC
-                      coverage: none
-                      experimental: false
+                      symfony-version: '5.4'
+                      coverage: xdebug
 
         steps:
             - name: Checkout
@@ -60,22 +40,17 @@ jobs:
                   coverage: ${{ matrix.coverage }}
                   ini-values: "memory_limit=-1"
                   php-version: ${{ matrix.php-version }}
-                  tools: composer:${{ matrix.composer-version }}
+                  tools: composer:v2, flex
 
             - name: Validate composer.json
               run: composer validate --no-check-lock
-
-            - name: Configure Symfony version
-              run: composer require --no-update symfony/framework-bundle "${{ matrix.symfony-version }}"
-
-            - name: Configure composer stability
-              if: matrix.stability != 'stable'
-              run: composer config minimum-stability "${{ matrix.stability }}"
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@v1
               with:
                   composer-options: "--prefer-dist"
+              env:
+                  SYMFONY_REQUIRE: "${{ matrix.symfony-version }}.*"
 
             - name: Setup problem matchers for PHP
               run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -654,7 +654,7 @@ class OldSoundRabbitMqExtension extends Extension
         $definition->addArgument(new Reference(sprintf('old_sound_rabbit_mq.connection.%s', $connectionName)));
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'old_sound_rabbit_mq';
     }

--- a/RabbitMq/BaseAmqp.php
+++ b/RabbitMq/BaseAmqp.php
@@ -55,9 +55,9 @@ abstract class BaseAmqp
     protected $eventDispatcher = null;
 
     /**
-     * @param AbstractConnection   $conn
-     * @param AMQPChannel|null $ch
-     * @param null             $consumerTag
+     * @param AbstractConnection $conn
+     * @param AMQPChannel|null   $ch
+     * @param string|null        $consumerTag
      */
     public function __construct(AbstractConnection $conn, AMQPChannel $ch = null, $consumerTag = null)
     {

--- a/composer.json
+++ b/composer.json
@@ -10,21 +10,21 @@
     "require": {
         "php":                          "^7.1|^8.0",
 
-        "symfony/dependency-injection": "^4.3|^5.0",
-        "symfony/event-dispatcher":     "^4.3|^5.0",
-        "symfony/config":               "^4.3|^5.0",
-        "symfony/yaml":                 "^4.3|^5.0",
-        "symfony/console":              "^4.3|^5.0",
+        "symfony/dependency-injection": "^4.3|^5.0|^6.0",
+        "symfony/event-dispatcher":     "^4.3|^5.0|^6.0",
+        "symfony/config":               "^4.3|^5.0|^6.0",
+        "symfony/yaml":                 "^4.3|^5.0|^6.0",
+        "symfony/console":              "^4.3|^5.0|^6.0",
         "php-amqplib/php-amqplib":      "^2.12.2|^3.0",
         "psr/log":                      "^1.0 || ^2.0 || ^3.0",
-        "symfony/http-kernel":          "^4.4|^5.0",
-        "symfony/framework-bundle":     "^4.4|^5.0"
+        "symfony/http-kernel":          "^4.4|^5.0|^6.0",
+        "symfony/framework-bundle":     "^4.4|^5.0|^6.0"
     },
     "require-dev": {
-        "symfony/serializer":           "^4.3|^5.0",
-        "phpunit/phpunit":              "^7.5|^8.5",
-        "phpstan/phpstan":              "^0.12.11",
-        "phpstan/phpstan-phpunit":      "^0.12.6"
+        "symfony/serializer":           "^4.3|^5.0|^6.0",
+        "phpunit/phpunit":              "^7.5|^8.5|^9.5",
+        "phpstan/phpstan":              "^1.2",
+        "phpstan/phpstan-phpunit":      "^1.0"
     },
     "replace": {
         "oldsound/rabbitmq-bundle": "self.version",


### PR DESCRIPTION
Alternative to #675 without hardening any runtime requirements.

See successful build here: https://github.com/javer/RabbitMqBundle/actions/runs/1606153171