### PR TITLE
lower PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "name" : "Alvaro Videla"
     }],
     "require": {
-        "php":                          "^7.4|^8.0",
+        "php":                          "^7.1.3|^8.0",
 
         "symfony/dependency-injection": "^4.4|^5.3|^6.0",
         "symfony/event-dispatcher":     "^4.4|^5.3|^6.0",


### PR DESCRIPTION
PHP interpreter version requirements lowered to same required by lowest Symfony version currently supported (4.4). Symfony 4.4.35 PHP version requirement is >=7.1.3.

https://github.com/symfony/symfony/blob/v4.4.35/composer.json