### PR TITLE
Fix for creating a stream context from a custom user parameters

### DIFF
--- a/RabbitMq/AMQPConnectionFactory.php
+++ b/RabbitMq/AMQPConnectionFactory.php
@@ -59,6 +59,7 @@ class AMQPConnectionFactory
                 ? stream_context_create(['ssl' => $this->parameters['ssl_context']])
                 : null;
         }
+        
         if ($parametersProvider) {
             $this->parameters = array_merge($this->parameters, $parametersProvider->getConnectionParameters());
         }

--- a/RabbitMq/AMQPConnectionFactory.php
+++ b/RabbitMq/AMQPConnectionFactory.php
@@ -53,16 +53,17 @@ class AMQPConnectionFactory
 
             $this->parameters['hosts'][$key] = $this->parseUrl($hostParameters);
         }
-
+        
+        if ($parametersProvider) {
+            $this->parameters = array_merge($this->parameters, $parametersProvider->getConnectionParameters());
+        }
+        
         if (is_array($this->parameters['ssl_context'])) {
             $this->parameters['context'] = ! empty($this->parameters['ssl_context'])
                 ? stream_context_create(['ssl' => $this->parameters['ssl_context']])
                 : null;
         }
         
-        if ($parametersProvider) {
-            $this->parameters = array_merge($this->parameters, $parametersProvider->getConnectionParameters());
-        }
     }
 
     /**


### PR DESCRIPTION
**What:**
Fix for dynamic using of `ssl_context => verify_peer` option.
In my case it was Local\AWS environment and there was no option to use one yml config for both environments.

**How to reproduce:**
On using custom class for an option `connection_parameters_provider: App\Service\ConnectionParametersProviderService`
I'm deciding to use or not SSL 
```
if ($this->verifyPeer !== null) {
   return ['ssl_context' => ['verify_peer' => $this->verifyPeer]];
}
return [];
```

But `RabbitMq/AMQPConnectionFactory.php` tries to create stream context for SSL options **before** it gets it from custom Connection parameters from users class, and there is no stream context for it.

In total, parameters looks like (invalid): 
```
[
  ...
  "ssl_context" => array:1 [
    "verify_peer" => true
  ]
  "context" => []
]
```
instead of (valid):
```
[
  ...
  "ssl_context" => array:1 [
    "verify_peer" => true
  ]
  "context" => stream-context resource @1392
    options: array:1 [
      "ssl" => array:1 [
        "verify_peer" => true
      ]
    ]
  }
]
```

**The fix:** 
Change the order of getting an `user parameters` and creating a `stream context`