### PR TITLE
Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.github export-ignore
+/Tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.scrutinizer.yml export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hello,

This PR add `.gitattributes` with `export-ignore` in order to reduce vendor size

More info here:
https://php.watch/articles/composer-gitattributes#export-ignore