### PR TITLE
fix deprecated for Symfony 6.4

### DIFF
--- a/OldSoundRabbitMqBundle.php
+++ b/OldSoundRabbitMqBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class OldSoundRabbitMqBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
@@ -20,7 +20,7 @@ class OldSoundRabbitMqBundle extends Bundle
     /**
      * {@inheritDoc}
      */
-    public function shutdown()
+    public function shutdown(): void
     {
         parent::shutdown();
         if (!$this->container->hasParameter('old_sound_rabbit_mq.base_amqp')) {


### PR DESCRIPTION
2023-11-14T11:38:05+00:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "OldSound\RabbitMqBundle\OldSoundRabbitMqBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-11-14T11:38:05+00:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::shutdown()" might add "void" as a native return type declaration in the future. Do the same in child class "OldSound\RabbitMqBundle\OldSoundRabbitMqBundle" now to avoid errors or add an explicit @return annotation to suppress this message.