### PR TITLE
Add support for Symfony 7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,13 @@ jobs:
         strategy:
             matrix:
                 php-version: ['7.4', '8.2']
-                symfony-version: ['4.4', '5.3', '5.4', '6.0']
+                symfony-version: ['4.4', '5.3', '5.4', '6.4', '7.0']
                 coverage: ['none']
                 exclude:
                     - php-version: '7.4'
-                      symfony-version: '6.0'
+                      symfony-version: '6.4'
+                    - php-version: '7.4'
+                      symfony-version: '7.0'
                 include:
                     - php-version: '8.0'
                       symfony-version: '5.4'

--- a/Command/BaseConsumerCommand.php
+++ b/Command/BaseConsumerCommand.php
@@ -70,7 +70,7 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
      * @throws \InvalidArgumentException When the number of messages to consume is less than 0
      * @throws \BadFunctionCallException When the pcntl is not installed and option -s is true
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (defined('AMQP_WITHOUT_SIGNALS') === false) {
             define('AMQP_WITHOUT_SIGNALS', $input->getOption('without-signals'));

--- a/Command/BaseRabbitMqCommand.php
+++ b/Command/BaseRabbitMqCommand.php
@@ -2,11 +2,10 @@
 
 namespace OldSound\RabbitMqBundle\Command;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
 
-abstract class BaseRabbitMqCommand extends Command implements ContainerAwareInterface
+abstract class BaseRabbitMqCommand extends Command
 {
     /**
      * @var ContainerInterface

--- a/Command/BatchConsumerCommand.php
+++ b/Command/BatchConsumerCommand.php
@@ -56,7 +56,7 @@ final class BatchConsumerCommand extends BaseRabbitMqCommand
      * @throws  \InvalidArgumentException       When the number of batches to consume is less than 0
      * @throws  \BadFunctionCallException       When the pcntl is not installed and option -s is true
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (defined('AMQP_WITHOUT_SIGNALS') === false) {
             define('AMQP_WITHOUT_SIGNALS', $input->getOption('without-signals'));

--- a/Command/DeleteCommand.php
+++ b/Command/DeleteCommand.php
@@ -33,7 +33,7 @@ class DeleteCommand extends ConsumerCommand
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $noConfirmation = (bool) $input->getOption('no-confirmation');
 

--- a/Command/PurgeConsumerCommand.php
+++ b/Command/PurgeConsumerCommand.php
@@ -33,7 +33,7 @@ class PurgeConsumerCommand extends ConsumerCommand
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $noConfirmation = (bool) $input->getOption('no-confirmation');
 

--- a/Command/RpcServerCommand.php
+++ b/Command/RpcServerCommand.php
@@ -32,7 +32,7 @@ class RpcServerCommand extends BaseRabbitMqCommand
      *
      * @throws \InvalidArgumentException When the number of messages to consume is less than 0
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         define('AMQP_DEBUG', (bool) $input->getOption('debug'));
         $amount = (int)$input->getOption('messages');

--- a/Command/StdInProducerCommand.php
+++ b/Command/StdInProducerCommand.php
@@ -34,7 +34,7 @@ class StdInProducerCommand extends BaseRabbitMqCommand
      *
      * @return integer 0 if everything went fine, or an error code
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         define('AMQP_DEBUG', (bool) $input->getOption('debug'));
 

--- a/DependencyInjection/Compiler/ServiceContainerPass.php
+++ b/DependencyInjection/Compiler/ServiceContainerPass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\DependencyInjection\Compiler;
+
+use OldSound\RabbitMqBundle\Command\BaseRabbitMqCommand;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ServiceContainerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('console.command') as $id => $attributes) {
+            $command = $container->findDefinition($id);
+            if (is_a($command->getClass(), BaseRabbitMqCommand::class, true)) {
+                $command->addMethodCall('setContainer', [new Reference('service_container')]);
+            }
+        }
+    }
+}

--- a/OldSoundRabbitMqBundle.php
+++ b/OldSoundRabbitMqBundle.php
@@ -4,6 +4,7 @@ namespace OldSound\RabbitMqBundle;
 
 use OldSound\RabbitMqBundle\DependencyInjection\Compiler\InjectEventDispatcherPass;
 use OldSound\RabbitMqBundle\DependencyInjection\Compiler\RegisterPartsPass;
+use OldSound\RabbitMqBundle\DependencyInjection\Compiler\ServiceContainerPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -15,6 +16,7 @@ class OldSoundRabbitMqBundle extends Bundle
 
         $container->addCompilerPass(new RegisterPartsPass());
         $container->addCompilerPass(new InjectEventDispatcherPass());
+        $container->addCompilerPass(new ServiceContainerPass());
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,18 @@
     "require": {
         "php":                          "^7.4|^8.0",
 
-        "symfony/dependency-injection": "^4.4|^5.3|^6.0",
-        "symfony/event-dispatcher":     "^4.4|^5.3|^6.0",
-        "symfony/config":               "^4.4|^5.3|^6.0",
-        "symfony/yaml":                 "^4.4|^5.3|^6.0",
-        "symfony/console":              "^4.4|^5.3|^6.0",
+        "symfony/dependency-injection": "^4.4|^5.3|^6.0|^7.0",
+        "symfony/event-dispatcher":     "^4.4|^5.3|^6.0|^7.0",
+        "symfony/config":               "^4.4|^5.3|^6.0|^7.0",
+        "symfony/yaml":                 "^4.4|^5.3|^6.0|^7.0",
+        "symfony/console":              "^4.4|^5.3|^6.0|^7.0",
         "php-amqplib/php-amqplib":      "^2.12.2|^3.0",
         "psr/log":                      "^1.0 || ^2.0 || ^3.0",
-        "symfony/http-kernel":          "^4.4|^5.3|^6.0",
-        "symfony/framework-bundle":     "^4.4|^5.3|^6.0"
+        "symfony/http-kernel":          "^4.4|^5.3|^6.0|^7.0",
+        "symfony/framework-bundle":     "^4.4|^5.3|^6.0|^7.0"
     },
     "require-dev": {
-        "symfony/serializer":           "^4.4|^5.3|^6.0",
+        "symfony/serializer":           "^4.4|^5.3|^6.0|^7.0",
         "phpunit/phpunit":              "^9.5",
         "phpstan/phpstan":              "^1.2",
         "phpstan/phpstan-phpunit":      "^1.0"


### PR DESCRIPTION
Hello,

This PR should resolve #720.
I mark this PR as draft, because I want to test some other scenarios and versions.

The main problem with upgrade to Symfony7  was with service container. Symfony 7 removed ContainerAwareInterface. 
This interface was [deprecated since 6.4](https://github.com/symfony/dependency-injection/blob/50b32f96f7e8f43b1ec4904df3be04438c0e4c13/ContainerAwareInterface.php#L19)

My solution is to pass ServiceContainer with public services via CompilerPass.

IMHO We should migrate to Service Locator(from my test this works too). There is only issue with backward compatibility. 
The ServiceLocator implements ContainerInterface from Psr namespace not from Symfony.
[The Symfony interface extends from Psr interface](https://github.com/symfony/dependency-injection/blob/50b32f96f7e8f43b1ec4904df3be04438c0e4c13/ContainerInterface.php#L25)
In bundle I did not find any calls to those extra methods, but someone could call one and this break backward compatibility.

@mihaileu if you are interested with migration to ServiceLocator I can prepare another PR.