### PR TITLE
Fix PHPDoc return typehint in BatchConsumerInterface::batchExecute()

### DIFF
--- a/RabbitMq/BatchConsumerInterface.php
+++ b/RabbitMq/BatchConsumerInterface.php
@@ -9,7 +9,7 @@ interface BatchConsumerInterface
     /**
      * @param   AMQPMessage[]   $messages
      *
-     * @return  array|bool
+     * @return  array|int|bool
      */
     public function batchExecute(array $messages);
 }


### PR DESCRIPTION
Hi there! :wave: 

In this PR I'm suggesting to fix PHPDoc and add `int` as possible return types for `BatchConsumerInterface::batchExecute()`

The reason:

We're analyzing the result of `BatchConsumerInterface::batchExecute()` in:
[\OldSound\RabbitMqBundle\RabbitMq\BatchConsumer::batchConsume](https://github.com/php-amqplib/RabbitMqBundle/blob/eec4e4e35d0b48f2d955d73a984c4dddcc1a135b/RabbitMq/BatchConsumer.php#L147)
-> \OldSound\RabbitMqBundle\RabbitMq\BatchConsumer::handleProcessMessages
-> [\OldSound\RabbitMqBundle\RabbitMq\BatchConsumer::analyzeProcessFlags](https://github.com/php-amqplib/RabbitMqBundle/blob/eec4e4e35d0b48f2d955d73a984c4dddcc1a135b/RabbitMq/BatchConsumer.php#L267)
-> [\OldSound\RabbitMqBundle\RabbitMq\BatchConsumer::handleProcessFlag](https://github.com/php-amqplib/RabbitMqBundle/blob/eec4e4e35d0b48f2d955d73a984c4dddcc1a135b/RabbitMq/BatchConsumer.php#L212)

Inside `BatchConsumer::handleProcessFlag()` we can see that **the value is compared against integer constants**.
And inside `BatchConsumer::analyzeProcessFlags()` its clear that if `$processFlags` isn't passed as array then the value would be formed as array of `$deliveryTag` -> `$processFlags`, so initial result of `BatchConsumerInterface::batchExecute()` is used here.

We discovered this issue while increasing the strictness of our static code analyzer.

Thanks for your time!