### PR TITLE
Fix routingkey in logged message

### DIFF
--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -67,7 +67,7 @@ class Producer extends BaseAmqp implements ProducerInterface
         $this->logger->debug('AMQP message published', [
             'amqp' => [
                 'body' => $msgBody,
-                'routingkeys' => $routingKey,
+                'routingkey' => $real_routingKey,
                 'properties' => $additionalProperties,
                 'headers' => $headers,
             ],


### PR DESCRIPTION
When we rely on default routing key param, the logged routing key is null, instead of the default routing key used for publishing the message.

Also, there's only one routing key used, then remove the plural in the parameter name.

