### PR TITLE
Add Producer events

### DIFF
--- a/Event/AMQPEvent.php
+++ b/Event/AMQPEvent.php
@@ -3,8 +3,8 @@
 namespace OldSound\RabbitMqBundle\Event;
 
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+use OldSound\RabbitMqBundle\RabbitMq\Producer;
 use PhpAmqpLib\Message\AMQPMessage;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class AMQPEvent
@@ -18,6 +18,8 @@ class AMQPEvent extends AbstractAMQPEvent
     public const ON_IDLE                   = 'on_idle';
     public const BEFORE_PROCESSING_MESSAGE = 'before_processing';
     public const AFTER_PROCESSING_MESSAGE  = 'after_processing';
+    public const BEFORE_PUBLISH_MESSAGE = 'before_publishing';
+    public const AFTER_PUBLISH_MESSAGE  = 'after_publishing';
 
     /**
      * @var AMQPMessage
@@ -28,6 +30,11 @@ class AMQPEvent extends AbstractAMQPEvent
      * @var Consumer
      */
     protected $consumer;
+
+    /**
+     * @var Producer
+     */
+    protected $producer;
 
     /**
      * @return AMQPMessage
@@ -65,6 +72,26 @@ class AMQPEvent extends AbstractAMQPEvent
     public function setConsumer(Consumer $consumer)
     {
         $this->consumer = $consumer;
+
+        return $this;
+    }
+
+    /**
+     * @return Producer
+     */
+    public function getProducer()
+    {
+        return $this->producer;
+    }
+
+    /**
+     * @param Producer $producer
+     *
+     * @return AMQPEvent
+     */
+    public function setProducer(Producer $producer)
+    {
+        $this->producer = $producer;
 
         return $this;
     }

--- a/Event/AfterProducerPublishMessageEvent.php
+++ b/Event/AfterProducerPublishMessageEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Event;
+
+use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use PhpAmqpLib\Message\AMQPMessage;
+
+/**
+ * Class AfterProducerPublishMessageEvent
+ *
+ * @package OldSound\RabbitMqBundle\Command
+ */
+class AfterProducerPublishMessageEvent extends AMQPEvent
+{
+    public const NAME = AMQPEvent::AFTER_PROCESSING_MESSAGE;
+
+    /**
+     * @var string
+     */
+    protected $routingKey;
+
+    /**
+     * AfterProducerPublishMessageEvent constructor.
+     *
+     * @param AMQPMessage $AMQPMessage
+     */
+    public function __construct(Producer $producer, AMQPMessage $AMQPMessage, string $routingKey)
+    {
+        $this->setProducer($producer);
+        $this->setAMQPMessage($AMQPMessage);
+        $this->routingKey = $routingKey;
+    }
+
+    /**
+     * @return AMQPMessage
+     */
+    public function getRoutingKey()
+    {
+        return $this->routingKey;
+    }
+}

--- a/Event/AfterProducerPublishMessageEvent.php
+++ b/Event/AfterProducerPublishMessageEvent.php
@@ -32,7 +32,7 @@ class AfterProducerPublishMessageEvent extends AMQPEvent
     }
 
     /**
-     * @return AMQPMessage
+     * @return string
      */
     public function getRoutingKey()
     {

--- a/Event/BeforeProducerPublishMessageEvent.php
+++ b/Event/BeforeProducerPublishMessageEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace OldSound\RabbitMqBundle\Event;
+
+use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use PhpAmqpLib\Message\AMQPMessage;
+
+/**
+ * Class BeforeProducerPublishMessageEvent
+ *
+ * @package OldSound\RabbitMqBundle\Command
+ */
+class BeforeProducerPublishMessageEvent extends AMQPEvent
+{
+    public const NAME = AMQPEvent::BEFORE_PROCESSING_MESSAGE;
+
+    /**
+     * @var string
+     */
+    protected $routingKey;
+
+    /**
+     * BeforeProducerPublishMessageEvent constructor.
+     *
+     * @param AMQPMessage $AMQPMessage
+     */
+    public function __construct(Producer $producer, AMQPMessage $AMQPMessage, string $routingKey)
+    {
+        $this->setProducer($producer);
+        $this->setAMQPMessage($AMQPMessage);
+        $this->routingKey = $routingKey;
+    }
+
+    /**
+     * @return AMQPMessage
+     */
+    public function getRoutingKey()
+    {
+        return $this->routingKey;
+    }
+}

--- a/Event/BeforeProducerPublishMessageEvent.php
+++ b/Event/BeforeProducerPublishMessageEvent.php
@@ -32,7 +32,7 @@ class BeforeProducerPublishMessageEvent extends AMQPEvent
     }
 
     /**
-     * @return AMQPMessage
+     * @return string
      */
     public function getRoutingKey()
     {

--- a/README.md
+++ b/README.md
@@ -316,6 +316,49 @@ If you need to use a custom class for a producer (which should inherit from `Old
 
 The next piece of the puzzle is to have a consumer that will take the message out of the queue and process it accordingly.
 
+#### Producer Events ####
+
+There are currently two events emitted by the producer.
+
+##### BeforeProducerPublishMessageEvent #####
+This event occurs immediately before publishing the message. This is a good hook to do any final logging, validation, etc. before actually sending the message. A sample implementation of a listener:
+
+```php
+namespace App\EventListener;
+
+use OldSound\RabbitMqBundle\Event\BeforeProducerPublishMessageEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: BeforeProducerPublishMessageEvent::NAME)]
+final class AMQPBeforePublishEventListener
+{
+    public function __invoke(BeforeProducerPublishMessageEvent $event): void
+    {
+        // Your code goes here
+    }
+}
+```
+
+##### AfterProducerPublishMessageEvent #####
+This event occurs immediately after publishing the message. This is a good hook to do any confirmation logging, commits, etc. after actually sending the message. A sample implementation of a listener:
+
+```php
+namespace App\EventListener;
+
+use OldSound\RabbitMqBundle\Event\AfterProducerPublishMessageEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: AfterProducerPublishMessageEvent::NAME)]
+final class AMQPBeforePublishEventListener
+{
+    public function __invoke(AfterProducerPublishMessageEvent $event): void
+    {
+        // Your code goes here
+    }
+}
+```
+
+
 ### Consumers ###
 
 A consumer will connect to the server and start a __loop__  waiting for incoming messages to process. Depending on the specified __callback__ for such consumer will be the behavior it will have. Let's review the consumer configuration from above:


### PR DESCRIPTION
Currently, Consumers have events which allow users of the bundle to add custom code. This PR adds this support to Producers as well. Really useful for project specific logging, message format validation, etc.

The only real difference between the Consumer and Producer events is the addition of the `routingKey` field in the Events, as `$producer->routingKey` is only set in the case where it is explicitly set, and not in the case where `defaultRoutingKey` is used. This PR currently works around this by providing that extra field, but it might be better to change `Producer.php` (line 67) from:

```php
$real_routingKey = $routingKey !== null ? $routingKey : $this->defaultRoutingKey;
```

to 

```php
if ($routingKey === null) {
    $routingKey = $this->defaultRoutingKey;
}
```

and then removing the extra `routingKey` field from the Events. Happy to take feedback on which way you'd prefer this one go.

My use case for this support is message validation prior to publishing.