### PR TITLE
 php-amqplib/php-amqplib >= 3.2 required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/config":               "^4.4|^5.3|^6.0|^7.0",
         "symfony/yaml":                 "^4.4|^5.3|^6.0|^7.0",
         "symfony/console":              "^4.4|^5.3|^6.0|^7.0",
-        "php-amqplib/php-amqplib":      "^2.12.2|^3.0",
+        "php-amqplib/php-amqplib":      "^3.2",
         "psr/log":                      "^1.0 || ^2.0 || ^3.0",
         "symfony/http-kernel":          "^4.4|^5.3|^6.0|^7.0",
         "symfony/framework-bundle":     "^4.4|^5.3|^6.0|^7.0"


### PR DESCRIPTION
Due to the usage of PhpAmqpLib\Connection\AMQPConnectionConfig, php-amqplib/php-amqplib >= 3.2 is required.