### PR TITLE
Handle SIGQUIT signal

### DIFF
--- a/Command/BaseConsumerCommand.php
+++ b/Command/BaseConsumerCommand.php
@@ -83,6 +83,7 @@ abstract class BaseConsumerCommand extends BaseRabbitMqCommand
 
             pcntl_signal(SIGTERM, [&$this, 'stopConsumer']);
             pcntl_signal(SIGINT, [&$this, 'stopConsumer']);
+            pcntl_signal(SIGQUIT, [&$this, 'stopConsumer']);
             pcntl_signal(SIGHUP, [&$this, 'restartConsumer']);
         }
 

--- a/Command/BatchConsumerCommand.php
+++ b/Command/BatchConsumerCommand.php
@@ -69,6 +69,7 @@ final class BatchConsumerCommand extends BaseRabbitMqCommand
 
             pcntl_signal(SIGTERM, [&$this, 'stopConsumer']);
             pcntl_signal(SIGINT, [&$this, 'stopConsumer']);
+            pcntl_signal(SIGQUIT, [&$this, 'stopConsumer']);
         }
 
         if (defined('AMQP_DEBUG') === false) {


### PR DESCRIPTION
As both PHP-FPM and NGINX use SIGQUIT for graceful shutdown, I believe it's necessary PHP applications should also support it. It's especially important in cases where you run PHP application in container running php/nginx image, since they override shutdown signal that docker uses to SIGQUIT, see eg. https://github.com/nginx/docker-nginx/commit/3fb70ddd7094c1fdd50cc83d432643dc10ab6243 