### PR TITLE
SetupFabricCommand: Add --skip-anon-consumers option

### DIFF
--- a/Tests/Command/SetupFabricCommandTest.php
+++ b/Tests/Command/SetupFabricCommandTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OldSound\RabbitMqBundle\Tests\Command;
+
+use OldSound\RabbitMqBundle\Command\SetupFabricCommand;
+use OldSound\RabbitMqBundle\RabbitMq\AmqpPartsHolder;
+use OldSound\RabbitMqBundle\RabbitMq\AnonConsumer;
+use OldSound\RabbitMqBundle\RabbitMq\BatchConsumer;
+use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+use OldSound\RabbitMqBundle\RabbitMq\DynamicConsumer;
+use OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @covers \OldSound\RabbitMqBundle\Command\SetupFabricCommand
+ */
+class SetupFabricCommandTest extends KernelTestCase
+{
+    public function testExecute(): void
+    {
+        $application = $this->createApplication();
+
+        $command = new SetupFabricCommand();
+        $container = $application->getKernel()->getContainer();
+
+        $partsHolder = new AmqpPartsHolder();
+        $consumer = $this->createMock(Consumer::class);
+        $consumer->expects($this->once())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $consumer);
+
+        $multipleConsumer = $this->createMock(MultipleConsumer::class);
+        $multipleConsumer->expects($this->once())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $multipleConsumer);
+
+        $batchConsumer = $this->createMock(BatchConsumer::class);
+        $batchConsumer->expects($this->once())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $batchConsumer);
+
+        $anonConsumer = $this->createMock(AnonConsumer::class);
+        $anonConsumer->expects($this->once())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $anonConsumer);
+
+        $dynamicConsumer = $this->createMock(DynamicConsumer::class);
+        $dynamicConsumer->expects($this->never())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $dynamicConsumer);
+
+        $container->set('old_sound_rabbit_mq.parts_holder', $partsHolder);
+
+        $command->setContainer($container);
+
+        // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
+        $application->add($command);
+
+        $registeredCommand = $application->find('rabbitmq:setup-fabric');
+
+        $commandTester = new CommandTester($registeredCommand);
+
+        $commandTester->execute([
+            'command'  => $registeredCommand->getName(),
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+        ]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testExecute_withSkipAnonConsumers(): void
+    {
+        $application = $this->createApplication();
+
+        $command = new SetupFabricCommand();
+        $container = $application->getKernel()->getContainer();
+
+        $partsHolder = new AmqpPartsHolder();
+        $consumer = $this->createMock(Consumer::class);
+        $consumer->expects($this->once())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $consumer);
+
+        $multipleConsumer = $this->createMock(MultipleConsumer::class);
+        $multipleConsumer->expects($this->once())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $multipleConsumer);
+
+        $batchConsumer = $this->createMock(BatchConsumer::class);
+        $batchConsumer->expects($this->once())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $batchConsumer);
+
+        $anonConsumer = $this->createMock(AnonConsumer::class);
+        $anonConsumer->expects($this->never())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $anonConsumer);
+
+        $dynamicConsumer = $this->createMock(DynamicConsumer::class);
+        $dynamicConsumer->expects($this->never())->method('setupFabric');
+        $partsHolder->addPart('old_sound_rabbit_mq.base_amqp', $dynamicConsumer);
+
+        $container->set('old_sound_rabbit_mq.parts_holder', $partsHolder);
+
+        $command->setContainer($container);
+
+        // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
+        $application->add($command);
+
+        $registeredCommand = $application->find('rabbitmq:setup-fabric');
+
+        $commandTester = new CommandTester($registeredCommand);
+
+        $commandTester->execute([
+            'command'  => $registeredCommand->getName(),
+            '--skip-anon-consumers' => true,
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+        ]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    private function createApplication(): Application
+    {
+        $kernel = self::createKernel();
+        $kernel->boot();
+
+        return new Application($kernel);
+    }
+}

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OldSound\RabbitMqBundle\Tests;
+
+use OldSound\RabbitMqBundle\OldSoundRabbitMqBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+final class TestKernel extends Kernel
+{
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new OldSoundRabbitMqBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,4 +26,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <php>
+        <server name="KERNEL_CLASS" value="\OldSound\RabbitMqBundle\Tests\TestKernel"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
Adds an `--skip-anon-consumers` option to the `SetupFabricCommand` (`rabbitmq:setup-fabric`).
Which will skip the `setupFabric()` method call on `AnonConsumer`s if the option is set. The behaviour is the same as now if the option is not set.

### Our use case:
We have producer and consumer containers.
These run the `rabbitmq:setup-fabric` command on startup.
We have set the `auto_setup_fabric` config to `false` on our producers & consumers.

This way, we can ensure that all needed exchanges & queues exist after the container has started. And the exchanges & queues are not redeclared every time we publish a message or restart a consumer.

#### Problem we run into:
We also have anonymous consumers. For those, we observe that the anonymous / auto-delete queues that are created by the `rabbitmq:setup-fabric` command are never deleted.
This may be the case, because we use the same RabbitMQ bundle configuration for our producer & consumer containers (we'd like to keep it that way if possible, makes it easier). Thus, the anon consumers are also configured on the producer containers. And those create a new auto-delete queue when they run the `rabbitmq:setup-fabric` command. I'm not 100% sure, but I suspect these queues are never deleted, because there's never a consumer for them.

The easiest fix I see is, to just add the ability to ignore the anon consumers when running the command.