### PR TITLE
Add support for Symfony 8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ['8.2', '8.3', '8.4', '8.5']
-                symfony-version: ['6.4', '7.4']
+                symfony-version: ['6.4', '7.4', '8.0']
                 coverage: ['none']
                 include:
                   - php-version: '8.3'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,13 +10,26 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['8.2', '8.3', '8.4', '8.5']
-                symfony-version: ['6.4', '7.4', '8.0']
-                coverage: ['none']
-                include:
-                  - php-version: '8.3'
-                    symfony-version: '6.4'
-                    coverage: xdebug
+              include:
+                - php-version: '8.2'
+                  symfony-version: '6.4'
+                  coverage: none
+
+                - php-version: '8.3'
+                  symfony-version: '7.4'
+                  coverage: none
+
+                - php-version: '8.4'
+                  symfony-version: '8.0'
+                  coverage: none
+
+                - php-version: '8.4'
+                  symfony-version: '7.4'
+                  coverage: none
+
+                - php-version: '8.3'
+                  symfony-version: '6.4'
+                  coverage: xdebug
 
         steps:
             - name: Checkout
@@ -34,7 +47,7 @@ jobs:
               run: composer validate --no-check-lock
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v2
               with:
                   composer-options: "--prefer-dist"
               env:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,12 @@
 build:
+    environment:
+        php:
+            version: 8.2
     dependencies:
         before:
             - composer config minimum-stability RC
+        override:
+            - composer install --prefer-dist --no-interaction
     nodes:
         analysis:
             tests:

--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -21,7 +21,7 @@ class MessageDataCollector extends DataCollector
         $this->data = [];
     }
 
-    public function collect(Request $request, Response $response, ?\Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         foreach ($this->channels as $channel) {
             foreach ($channel->getBasicPublishLog() as $log) {
@@ -30,22 +30,22 @@ class MessageDataCollector extends DataCollector
         }
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'rabbit_mq';
     }
 
-    public function getPublishedMessagesCount()
+    public function getPublishedMessagesCount(): int
     {
         return count($this->data);
     }
 
-    public function getPublishedMessagesLog()
+    public function getPublishedMessagesLog(): array
     {
         return $this->data;
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/DataCollector/MessageDataCollector.php
+++ b/DataCollector/MessageDataCollector.php
@@ -15,17 +15,20 @@ class MessageDataCollector extends DataCollector
 {
     private $channels;
 
+    /** @var array */
+    private $messages;
+
     public function __construct($channels)
     {
         $this->channels = $channels;
-        $this->data = [];
+        $this->messages = [];
     }
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         foreach ($this->channels as $channel) {
             foreach ($channel->getBasicPublishLog() as $log) {
-                $this->data[] = $log;
+                $this->messages[] = $log;
             }
         }
     }
@@ -37,16 +40,16 @@ class MessageDataCollector extends DataCollector
 
     public function getPublishedMessagesCount(): int
     {
-        return count($this->data);
+        return count($this->messages);
     }
 
     public function getPublishedMessagesLog(): array
     {
-        return $this->data;
+        return $this->messages;
     }
 
     public function reset(): void
     {
-        $this->data = [];
+        $this->messages = [];
     }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All the examples expect a running RabbitMQ server.
 
 This bundle was presented at [Symfony Live Paris 2011](http://www.symfony-live.com/paris/schedule#session-av1) conference. See the slides [here](http://www.slideshare.net/old_sound/theres-a-rabbit-on-my-symfony).
 
-## Version 2 ##
+## Version 2 ##vendor/bin/phpunit
 Due to the breaking changes happened caused by Symfony >=4.4, a new tag was released, making the bundle compatible with Symfony >=4.4.
 
 ## Installation ##

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All the examples expect a running RabbitMQ server.
 
 This bundle was presented at [Symfony Live Paris 2011](http://www.symfony-live.com/paris/schedule#session-av1) conference. See the slides [here](http://www.slideshare.net/old_sound/theres-a-rabbit-on-my-symfony).
 
-## Version 2 ##vendor/bin/phpunit
+## Version 2 ##
 Due to the breaking changes happened caused by Symfony >=4.4, a new tag was released, making the bundle compatible with Symfony >=4.4.
 
 ## Installation ##

--- a/Tests/Command/SetupFabricCommandTest.php
+++ b/Tests/Command/SetupFabricCommandTest.php
@@ -54,7 +54,6 @@ class SetupFabricCommandTest extends KernelTestCase
         $command->setContainer($container);
 
         // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
-        // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
         if (method_exists($application, 'addCommand')) {
             $application->addCommand($command);
         } else {
@@ -107,7 +106,6 @@ class SetupFabricCommandTest extends KernelTestCase
 
         $command->setContainer($container);
 
-        // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
         // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
         if (method_exists($application, 'addCommand')) {
             $application->addCommand($command);

--- a/Tests/Command/SetupFabricCommandTest.php
+++ b/Tests/Command/SetupFabricCommandTest.php
@@ -54,7 +54,13 @@ class SetupFabricCommandTest extends KernelTestCase
         $command->setContainer($container);
 
         // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
-        $application->add($command);
+        // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            // @phpstan-ignore-next-line
+            $application->add($command);
+        }
 
         $registeredCommand = $application->find('rabbitmq:setup-fabric');
 
@@ -102,7 +108,13 @@ class SetupFabricCommandTest extends KernelTestCase
         $command->setContainer($container);
 
         // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
-        $application->add($command);
+        // TODO: Use addCommand() once Symfony Support for < 7.4 is dropped
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            // @phpstan-ignore-next-line
+            $application->add($command);
+        }
 
         $registeredCommand = $application->find('rabbitmq:setup-fabric');
 

--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
         "name" : "Alvaro Videla"
     }],
     "require": {
-        "php":                          "^8.2",
-        "symfony/dependency-injection": "^6.0 || ^7.0",
-        "symfony/event-dispatcher":     "^6.0 || ^7.0",
-        "symfony/config":               "^6.0 || ^7.0",
-        "symfony/yaml":                 "^6.0 || ^7.0",
-        "symfony/console":              "^6.0 || ^7.0",
+        "php":                          "^8.4",
+        "symfony/dependency-injection": "^6.0 || ^7.0 || ^8.0",
+        "symfony/event-dispatcher":     "^6.0 || ^7.0 || ^8.0",
+        "symfony/config":               "^6.0 || ^7.0 || ^8.0",
+        "symfony/yaml":                 "^6.0 || ^7.0 || ^8.0",
+        "symfony/console":              "^6.0 || ^7.0 || ^8.0",
         "php-amqplib/php-amqplib":      "^2.12.2 || ^3.0",
         "psr/log":                      "^2.0 || ^3.0",
-        "symfony/http-kernel":          "^6.0 || ^7.0",
-        "symfony/framework-bundle":     "^6.0 || ^7.0"
+        "symfony/http-kernel":          "^6.0 || ^7.0 || ^8.0",
+        "symfony/framework-bundle":     "^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "symfony/serializer":           "^6.0 || ^7.0",
+        "symfony/serializer":           "^6.0 || ^7.0 || ^8.0",
         "phpunit/phpunit":              "^9.5",
         "phpstan/phpstan":              "^1.2",
         "phpstan/phpstan-phpunit":      "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "name" : "Alvaro Videla"
     }],
     "require": {
-        "php":                          "^8.4",
+        "php":                          "^8.2",
         "symfony/dependency-injection": "^6.0 || ^7.0 || ^8.0",
         "symfony/event-dispatcher":     "^6.0 || ^7.0 || ^8.0",
         "symfony/config":               "^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
Hi! 

### Summary
This PR adds support for Symfony 8 while maintaining backward compatibility with Symfony 6.x and 7.x.

**Closes:** #742 

### Changes Made
**composer.json:**
- Updated all `symfony/*` dependencies to support `^6.0 || ^7.0 || ^8.0`
- Updated minimum PHP version to `^8.4` to align with Symfony 8 requirements

**Code updates:**
- Updated type hints in classes to be compatible with Symfony 8
- Fixed tests to work with the new Symfony version

### Testing
I have tested all major bundle features on a Symfony 8.0 project:

 **Producers:**
- `rabbitmq:stdin-producer` - basic message publishing
- `rabbitmq:stdin-producer --route=<key>` - publishing with routing keys
- Producer service injection and programmatic usage

**Consumers:**
- `rabbitmq:consumer` - single consumer execution
- `rabbitmq:multiple-consumer` - multiple consumers on shared queues

**Routing:**
- Topic exchange with pattern matching (`*.error`, `app.*`, `#`)
- Direct exchange with specific routing keys
- Multiple consumers bound to the same queue (load balancing)
- Multiple routing keys per consumer

All commands execute successfully without any deprecation warnings or errors on Symfony 8.0.

### Notes for Reviewers
This is my first contribution to an open-source project, and I'm new to the contribution process. I've done my best to:
- Follow the existing code style
- Test thoroughly on Symfony 8
- Maintain backward compatibility

I would greatly appreciate any feedback on:
- Code quality and implementation approach
- Any project conventions I might have missed
- Documentation updates that should be included

Please feel free to request any changes or improvements. I'm eager to learn and happy to make adjustments to meet the project's standards.

Thank you for maintaining this excellent bundle! 🙏