### PR TITLE
Feature/cosmetics

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,16 +56,13 @@ jobs:
             - name: Setup problem matchers for PHP
               run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-            - name: Setup problem matchers for PHPUnit
-              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-            - name: Run PHPUnit
+            - name: Run Pest
               if: matrix.coverage == 'none'
-              run: vendor/bin/phpunit
+              run: vendor/bin/pest
 
-            - name: Run PHPUnit with coverage
+            - name: Run Pest with coverage
               if: matrix.coverage != 'none'
-              run: vendor/bin/phpunit --coverage-clover=coverage.clover
+              run: vendor/bin/pest --coverage-clover=coverage.clover
 
             - name: Run PHPStan
               run: vendor/bin/phpstan analyse

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ composer.phar
 vendor
 .phpunit.result.cache
 .php-cs-fixer.cache
+.idea/phpunit.xml
+/var/cache/*
+/.idea

--- a/Tests/Command/BaseCommandTest.php
+++ b/Tests/Command/BaseCommandTest.php
@@ -1,31 +1,5 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Command;
-
-use PHPUnit\Framework\TestCase;
-
-abstract class BaseCommandTest extends TestCase
-{
-    protected $application;
-    protected $definition;
-    protected $helperSet;
-    protected $command;
-
-    protected function setUp(): void
-    {
-        $this->application = $this->getMockBuilder('Symfony\\Component\\Console\\Application')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->definition = $this->getMockBuilder('Symfony\\Component\\Console\\Input\\InputDefinition')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->helperSet = $this->getMockBuilder('Symfony\\Component\\Console\\Helper\\HelperSet')->getMock();
-
-        $this->application->expects($this->any())
-            ->method('getDefinition')
-            ->will($this->returnValue($this->definition));
-        $this->definition->expects($this->any())
-            ->method('getArguments')
-            ->will($this->returnValue([]));
-    }
-}
+// This file previously held an abstract BaseCommandTest class.
+// In Pest, shared setup is handled via beforeEach() in each test file directly,
+// since PHPUnit's protected getMockBuilder() cannot be called from global scope.

--- a/Tests/Command/ConsumerCommandTest.php
+++ b/Tests/Command/ConsumerCommandTest.php
@@ -1,51 +1,45 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Command;
-
 use OldSound\RabbitMqBundle\Command\ConsumerCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
-class ConsumerCommandTest extends BaseCommandTest
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->definition->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue([
-                new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
-                new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
-                new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
-            ]));
-        $this->application->expects($this->once())
-            ->method('getHelperSet')
-            ->will($this->returnValue($this->helperSet));
+beforeEach(function () {
+    $this->application = $this->getMockBuilder(Application::class)->disableOriginalConstructor()->getMock();
+    $this->definition  = $this->getMockBuilder(InputDefinition::class)->disableOriginalConstructor()->getMock();
+    $this->helperSet   = $this->getMockBuilder(HelperSet::class)->getMock();
 
-        $this->command = new ConsumerCommand();
-        $this->command->setApplication($this->application);
-    }
+    $this->application->method('getDefinition')->willReturn($this->definition);
+    $this->definition->method('getArguments')->willReturn([]);
+    $this->definition->method('getOptions')->willReturn([
+        new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
+        new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
+        new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
+    ]);
 
-    /**
-     * testInputsDefinitionCommand
-     */
-    public function testInputsDefinitionCommand()
-    {
-        $definition = $this->command->getDefinition();
-        // check argument
-        $this->assertTrue($definition->hasArgument('name'));
-        $this->assertTrue($definition->getArgument('name')->isRequired()); // Name is required to find the service
+    $this->application->expects($this->once())->method('getHelperSet')->willReturn($this->helperSet);
 
-        //check options
-        $this->assertTrue($definition->hasOption('messages'));
-        $this->assertTrue($definition->getOption('messages')->isValueOptional()); // It should accept value
+    $this->command = new ConsumerCommand();
+    $this->command->setApplication($this->application);
+});
 
-        $this->assertTrue($definition->hasOption('route'));
-        $this->assertTrue($definition->getOption('route')->isValueOptional()); // It should accept value
+test('consumer command has the correct input definition', function () {
+    $definition = $this->command->getDefinition();
 
-        $this->assertTrue($definition->hasOption('without-signals'));
-        $this->assertFalse($definition->getOption('without-signals')->acceptValue()); // It shouldn't accept value because it is a true/false input
+    expect($definition->hasArgument('name'))->toBeTrue();
+    expect($definition->getArgument('name')->isRequired())->toBeTrue();
 
-        $this->assertTrue($definition->hasOption('debug'));
-        $this->assertFalse($definition->getOption('debug')->acceptValue()); // It shouldn't accept value because it is a true/false input
-    }
-}
+    expect($definition->hasOption('messages'))->toBeTrue();
+    expect($definition->getOption('messages')->isValueOptional())->toBeTrue();
+
+    expect($definition->hasOption('route'))->toBeTrue();
+    expect($definition->getOption('route')->isValueOptional())->toBeTrue();
+
+    expect($definition->hasOption('without-signals'))->toBeTrue();
+    expect($definition->getOption('without-signals')->acceptValue())->toBeFalse();
+
+    expect($definition->hasOption('debug'))->toBeTrue();
+    expect($definition->getOption('debug')->acceptValue())->toBeFalse();
+});

--- a/Tests/Command/DynamicConsumerCommandTest.php
+++ b/Tests/Command/DynamicConsumerCommandTest.php
@@ -1,54 +1,48 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Command;
-
 use OldSound\RabbitMqBundle\Command\DynamicConsumerCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
-class DynamicConsumerCommandTest extends BaseCommandTest
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->definition->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue([
-                new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
-                new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
-                new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
-            ]));
-        $this->application->expects($this->once())
-            ->method('getHelperSet')
-            ->will($this->returnValue($this->helperSet));
+beforeEach(function () {
+    $this->application = $this->getMockBuilder(Application::class)->disableOriginalConstructor()->getMock();
+    $this->definition  = $this->getMockBuilder(InputDefinition::class)->disableOriginalConstructor()->getMock();
+    $this->helperSet   = $this->getMockBuilder(HelperSet::class)->getMock();
 
-        $this->command = new DynamicConsumerCommand();
-        $this->command->setApplication($this->application);
-    }
+    $this->application->method('getDefinition')->willReturn($this->definition);
+    $this->definition->method('getArguments')->willReturn([]);
+    $this->definition->method('getOptions')->willReturn([
+        new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
+        new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
+        new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
+    ]);
 
-    /**
-     * testInputsDefinitionCommand
-     */
-    public function testInputsDefinitionCommand()
-    {
-        // check argument
-        $definition = $this->command->getDefinition();
-        $this->assertTrue($definition->hasArgument('name'));
-        $this->assertTrue($definition->getArgument('name')->isRequired()); // Name is required to find the service
+    $this->application->expects($this->once())->method('getHelperSet')->willReturn($this->helperSet);
 
-        $this->assertTrue($definition->hasArgument('context'));
-        $this->assertTrue($definition->getArgument('context')->isRequired()); // Context is required for the queue options provider
+    $this->command = new DynamicConsumerCommand();
+    $this->command->setApplication($this->application);
+});
 
-        //check options
-        $this->assertTrue($definition->hasOption('messages'));
-        $this->assertTrue($definition->getOption('messages')->isValueOptional()); // It should accept value
+test('dynamic consumer command has the correct input definition', function () {
+    $definition = $this->command->getDefinition();
 
-        $this->assertTrue($definition->hasOption('route'));
-        $this->assertTrue($definition->getOption('route')->isValueOptional()); // It should accept value
+    expect($definition->hasArgument('name'))->toBeTrue();
+    expect($definition->getArgument('name')->isRequired())->toBeTrue();
 
-        $this->assertTrue($definition->hasOption('without-signals'));
-        $this->assertFalse($definition->getOption('without-signals')->acceptValue()); // It shouldn't accept value because it is a true/false input
+    expect($definition->hasArgument('context'))->toBeTrue();
+    expect($definition->getArgument('context')->isRequired())->toBeTrue();
 
-        $this->assertTrue($definition->hasOption('debug'));
-        $this->assertFalse($definition->getOption('debug')->acceptValue()); // It shouldn't accept value because it is a true/false input
-    }
-}
+    expect($definition->hasOption('messages'))->toBeTrue();
+    expect($definition->getOption('messages')->isValueOptional())->toBeTrue();
+
+    expect($definition->hasOption('route'))->toBeTrue();
+    expect($definition->getOption('route')->isValueOptional())->toBeTrue();
+
+    expect($definition->hasOption('without-signals'))->toBeTrue();
+    expect($definition->getOption('without-signals')->acceptValue())->toBeFalse();
+
+    expect($definition->hasOption('debug'))->toBeTrue();
+    expect($definition->getOption('debug')->acceptValue())->toBeFalse();
+});

--- a/Tests/Command/MultipleConsumerCommandTest.php
+++ b/Tests/Command/MultipleConsumerCommandTest.php
@@ -1,54 +1,48 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Command;
-
 use OldSound\RabbitMqBundle\Command\MultipleConsumerCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
-class MultipleConsumerCommandTest extends BaseCommandTest
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->definition->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue([
-                new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
-                new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
-                new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
-            ]));
-        $this->application->expects($this->once())
-            ->method('getHelperSet')
-            ->will($this->returnValue($this->helperSet));
+beforeEach(function () {
+    $this->application = $this->getMockBuilder(Application::class)->disableOriginalConstructor()->getMock();
+    $this->definition  = $this->getMockBuilder(InputDefinition::class)->disableOriginalConstructor()->getMock();
+    $this->helperSet   = $this->getMockBuilder(HelperSet::class)->getMock();
 
-        $this->command = new MultipleConsumerCommand();
-        $this->command->setApplication($this->application);
-    }
+    $this->application->method('getDefinition')->willReturn($this->definition);
+    $this->definition->method('getArguments')->willReturn([]);
+    $this->definition->method('getOptions')->willReturn([
+        new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
+        new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
+        new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
+    ]);
 
-    /**
-     * testInputsDefinitionCommand
-     */
-    public function testInputsDefinitionCommand()
-    {
-        // check argument
-        $definition = $this->command->getDefinition();
-        $this->assertTrue($definition->hasArgument('name'));
-        $this->assertTrue($definition->getArgument('name')->isRequired()); // Name is required to find the service
+    $this->application->expects($this->once())->method('getHelperSet')->willReturn($this->helperSet);
 
-        $this->assertTrue($definition->hasArgument('context'));
-        $this->assertFalse($definition->getArgument('context')->isRequired()); // Context is required for the queue options provider
+    $this->command = new MultipleConsumerCommand();
+    $this->command->setApplication($this->application);
+});
 
-        //check options
-        $this->assertTrue($definition->hasOption('messages'));
-        $this->assertTrue($definition->getOption('messages')->isValueOptional()); // It should accept value
+test('multiple consumer command has the correct input definition', function () {
+    $definition = $this->command->getDefinition();
 
-        $this->assertTrue($definition->hasOption('route'));
-        $this->assertTrue($definition->getOption('route')->isValueOptional()); // It should accept value
+    expect($definition->hasArgument('name'))->toBeTrue();
+    expect($definition->getArgument('name')->isRequired())->toBeTrue();
 
-        $this->assertTrue($definition->hasOption('without-signals'));
-        $this->assertFalse($definition->getOption('without-signals')->acceptValue()); // It shouldn't accept value because it is a true/false input
+    expect($definition->hasArgument('context'))->toBeTrue();
+    expect($definition->getArgument('context')->isRequired())->toBeFalse();
 
-        $this->assertTrue($definition->hasOption('debug'));
-        $this->assertFalse($definition->getOption('debug')->acceptValue()); // It shouldn't accept value because it is a true/false input
-    }
-}
+    expect($definition->hasOption('messages'))->toBeTrue();
+    expect($definition->getOption('messages')->isValueOptional())->toBeTrue();
+
+    expect($definition->hasOption('route'))->toBeTrue();
+    expect($definition->getOption('route')->isValueOptional())->toBeTrue();
+
+    expect($definition->hasOption('without-signals'))->toBeTrue();
+    expect($definition->getOption('without-signals')->acceptValue())->toBeFalse();
+
+    expect($definition->hasOption('debug'))->toBeTrue();
+    expect($definition->getOption('debug')->acceptValue())->toBeFalse();
+});

--- a/Tests/Command/PurgeCommandTest.php
+++ b/Tests/Command/PurgeCommandTest.php
@@ -1,40 +1,34 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Command;
-
 use OldSound\RabbitMqBundle\Command\PurgeConsumerCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
-class PurgeCommandTest extends BaseCommandTest
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->definition->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue([
-                new InputOption('--no-confirmation', null, InputOption::VALUE_NONE, 'Switches off confirmation mode.'),
-            ]));
-        $this->application->expects($this->once())
-            ->method('getHelperSet')
-            ->will($this->returnValue($this->helperSet));
+beforeEach(function () {
+    $this->application = $this->getMockBuilder(Application::class)->disableOriginalConstructor()->getMock();
+    $this->definition  = $this->getMockBuilder(InputDefinition::class)->disableOriginalConstructor()->getMock();
+    $this->helperSet   = $this->getMockBuilder(HelperSet::class)->getMock();
 
-        $this->command = new PurgeConsumerCommand();
-        $this->command->setApplication($this->application);
-    }
+    $this->application->method('getDefinition')->willReturn($this->definition);
+    $this->definition->method('getArguments')->willReturn([]);
+    $this->definition->method('getOptions')->willReturn([
+        new InputOption('--no-confirmation', null, InputOption::VALUE_NONE, 'Switches off confirmation mode.'),
+    ]);
 
-    /**
-     * testInputsDefinitionCommand
-     */
-    public function testInputsDefinitionCommand()
-    {
-        // check argument
-        $definition = $this->command->getDefinition();
-        $this->assertTrue($definition->hasArgument('name'));
-        $this->assertTrue($definition->getArgument('name')->isRequired()); // Name is required to find the service
+    $this->application->expects($this->once())->method('getHelperSet')->willReturn($this->helperSet);
 
-        //check options
-        $this->assertTrue($definition->hasOption('no-confirmation'));
-        $this->assertFalse($definition->getOption('no-confirmation')->acceptValue()); // It shouldn't accept value because it is a true/false input
-    }
-}
+    $this->command = new PurgeConsumerCommand();
+    $this->command->setApplication($this->application);
+});
+
+test('purge command has the correct input definition', function () {
+    $definition = $this->command->getDefinition();
+
+    expect($definition->hasArgument('name'))->toBeTrue();
+    expect($definition->getArgument('name')->isRequired())->toBeTrue();
+
+    expect($definition->hasOption('no-confirmation'))->toBeTrue();
+    expect($definition->getOption('no-confirmation')->acceptValue())->toBeFalse();
+});

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -1,11 +1,8 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\DependencyInjection;
-
 use OldSound\RabbitMqBundle\DependencyInjection\OldSoundRabbitMqExtension;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use OldSound\RabbitMqBundle\RabbitMq\ProducerInterface;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -13,1065 +10,551 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 
-class OldSoundRabbitMqExtensionTest extends TestCase
+function buildContainer(string $file, bool $debug = false): ContainerBuilder
 {
-    public function testFooConnectionDefinition()
-    {
-        $container = $this->getContainer('test.yml');
+    $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => $debug]));
+    $container->registerExtension(new OldSoundRabbitMqExtension());
 
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.foo_connection'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.connection.foo_connection');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.foo_connection'));
-        $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.foo_connection');
-        $this->assertEquals(['old_sound_rabbit_mq.connection_factory.foo_connection', 'createConnection'], $definition->getFactory());
-        $this->assertEquals([
-            'host' => 'foo_host',
-            'port' => 123,
-            'user' => 'foo_user',
-            'password' => 'foo_password',
-            'vhost' => '/foo',
-            'lazy' => false,
-            'connection_timeout' => 3,
-            'read_write_timeout' => 3,
-            'ssl_context' => [],
-            'keepalive' => false,
-            'heartbeat' => 0,
-            'use_socket' => false,
-            'url' => '',
-            'hosts' => [],
-            'channel_rpc_timeout' => 0.0,
-            'login_method' => 'AMQPLAIN',
+    $locator = new FileLocator(__DIR__ . '/Fixtures');
+    $loader  = new YamlFileLoader($container, $locator);
+    $loader->load($file);
 
-        ], $factory->getArgument(1));
-        $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
-    }
+    $container->getCompilerPassConfig()->setOptimizationPasses([]);
+    $container->getCompilerPassConfig()->setRemovingPasses([]);
+    $container->compile();
 
-    public function testSslConnectionDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.ssl_connection'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.connection.ssl_connection');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.ssl_connection'));
-        $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.ssl_connection');
-        $this->assertEquals(['old_sound_rabbit_mq.connection_factory.ssl_connection', 'createConnection'], $definition->getFactory());
-        $this->assertEquals([
-            'host' => 'ssl_host',
-            'port' => 123,
-            'user' => 'ssl_user',
-            'password' => 'ssl_password',
-            'vhost' => '/ssl',
-            'lazy' => false,
-            'connection_timeout' => 3,
-            'read_write_timeout' => 3,
-            'ssl_context' => [
-                'verify_peer' => false,
-            ],
-            'keepalive' => false,
-            'heartbeat' => 0,
-            'use_socket' => false,
-            'url' => '',
-            'hosts' => [],
-            'channel_rpc_timeout' => 0.0,
-            'login_method' => 'AMQPLAIN',
-        ], $factory->getArgument(1));
-        $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
-    }
-
-    public function testLazyConnectionDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.lazy_connection'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.connection.lazy_connection');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.lazy_connection'));
-        $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.lazy_connection');
-        $this->assertEquals(['old_sound_rabbit_mq.connection_factory.lazy_connection', 'createConnection'], $definition->getFactory());
-        $this->assertEquals([
-            'host' => 'lazy_host',
-            'port' => 456,
-            'user' => 'lazy_user',
-            'password' => 'lazy_password',
-            'vhost' => '/lazy',
-            'lazy' => true,
-            'connection_timeout' => 3,
-            'read_write_timeout' => 3,
-            'ssl_context' => [],
-            'keepalive' => false,
-            'heartbeat' => 0,
-            'use_socket' => false,
-            'url' => '',
-            'hosts' => [],
-            'channel_rpc_timeout' => 0.0,
-            'login_method' => 'AMQPLAIN',
-        ], $factory->getArgument(1));
-        $this->assertEquals('%old_sound_rabbit_mq.lazy.connection.class%', $definition->getClass());
-    }
-
-    public function testDefaultConnectionDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.default'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.connection.default');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.default'));
-        $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.default');
-        $this->assertEquals(['old_sound_rabbit_mq.connection_factory.default', 'createConnection'], $definition->getFactory());
-        $this->assertEquals([
-            'host' => 'localhost',
-            'port' => 5672,
-            'user' => 'guest',
-            'password' => 'guest',
-            'vhost' => '/',
-            'lazy' => false,
-            'connection_timeout' => 3,
-            'read_write_timeout' => 3,
-            'ssl_context' => [],
-            'keepalive' => false,
-            'heartbeat' => 0,
-            'use_socket' => false,
-            'url' => '',
-            'hosts' => [],
-            'channel_rpc_timeout' => 0.0,
-            'login_method' => 'AMQPLAIN',
-        ], $factory->getArgument(1));
-        $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
-    }
-
-    public function testSocketConnectionDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.socket_connection'));
-        $definiton = $container->getDefinition('old_sound_rabbit_mq.connection.socket_connection');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.socket_connection'));
-        $this->assertEquals('%old_sound_rabbit_mq.socket_connection.class%', $definiton->getClass());
-    }
-
-    public function testLazySocketConnectionDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.lazy_socket'));
-        $definiton = $container->getDefinition('old_sound_rabbit_mq.connection.lazy_socket');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.lazy_socket'));
-        $this->assertEquals('%old_sound_rabbit_mq.lazy.socket_connection.class%', $definiton->getClass());
-    }
-
-    public function testClusterConnectionDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection.cluster_connection'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.connection.cluster_connection');
-        $this->assertTrue($container->has('old_sound_rabbit_mq.connection_factory.cluster_connection'));
-        $factory = $container->getDefinition('old_sound_rabbit_mq.connection_factory.cluster_connection');
-        $this->assertEquals(['old_sound_rabbit_mq.connection_factory.cluster_connection', 'createConnection'], $definition->getFactory());
-        $this->assertEquals([
-            'hosts' => [
-                [
-                    'host' => 'cluster_host',
-                    'port' => 111,
-                    'user' => 'cluster_user',
-                    'password' => 'cluster_password',
-                    'vhost' => '/cluster',
-                    'url' => '',
-                ],
-                [
-                    'host' => 'localhost',
-                    'port' => 5672,
-                    'user' => 'guest',
-                    'password' => 'guest',
-                    'vhost' => '/',
-                    'url' => 'amqp://cluster_url_host:cluster_url_pass@host:10000/cluster_url_vhost',
-                ],
-            ],
-            'host' => 'localhost',
-            'port' => 5672,
-            'user' => 'guest',
-            'password' => 'guest',
-            'vhost' => '/',
-            'lazy' => false,
-            'connection_timeout' => 3,
-            'read_write_timeout' => 3,
-            'ssl_context' => [],
-            'keepalive' => false,
-            'heartbeat' => 0,
-            'use_socket' => false,
-            'url' => '',
-            'channel_rpc_timeout' => 0.0,
-            'login_method' => 'AMQPLAIN',
-        ], $factory->getArgument(1));
-        $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
-    }
-
-    public function testFooBinding()
-    {
-        $container = $this->getContainer('test.yml');
-        $binding = [
-            'arguments'                 => null,
-            'class'                     => '%old_sound_rabbit_mq.binding.class%',
-            'connection'                => 'default',
-            'exchange'                  => 'foo',
-            'destination'               => 'bar',
-            'destination_is_exchange'   => false,
-            'nowait'                    => false,
-            'routing_key'               => 'baz',
-        ];
-        ksort($binding);
-        $key = md5(json_encode($binding));
-        $name = sprintf('old_sound_rabbit_mq.binding.%s', $key);
-        $this->assertTrue($container->has($name));
-        $definition = $container->getDefinition($name);
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertBindingMethodCalls($definition, $binding);
-    }
-
-    public function testMooBinding()
-    {
-        $container = $this->getContainer('test.yml');
-        $binding = [
-            'arguments'                 => ['moo' => 'cow'],
-            'class'                     => '%old_sound_rabbit_mq.binding.class%',
-            'connection'                => 'default2',
-            'exchange'                  => 'moo',
-            'destination'               => 'cow',
-            'destination_is_exchange'   => true,
-            'nowait'                    => true,
-            'routing_key'               => null,
-        ];
-        ksort($binding);
-        $key = md5(json_encode($binding));
-        $name = sprintf('old_sound_rabbit_mq.binding.%s', $key);
-        $this->assertTrue($container->has($name));
-        $definition = $container->getDefinition($name);
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default2');
-        $this->assertBindingMethodCalls($definition, $binding);
-    }
-
-    protected function assertBindingMethodCalls(Definition $definition, $binding)
-    {
-        $this->assertEquals(
-            [
-            [
-                'setArguments',
-                [
-                    $binding['arguments'],
-                ],
-            ],
-            [
-                'setDestination',
-                [
-                    $binding['destination'],
-                ],
-            ],
-            [
-                'setDestinationIsExchange',
-                [
-                    $binding['destination_is_exchange'],
-                ],
-            ],
-            [
-                'setExchange',
-                [
-                    $binding['exchange'],
-                ],
-            ],
-            [
-                'isNowait',
-                [
-                    $binding['nowait'],
-                ],
-            ],
-            [
-                'setRoutingKey',
-                [
-                    $binding['routing_key'],
-                ],
-            ],
-        ],
-            $definition->getMethodCalls()
-        );
-    }
-    public function testFooProducerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_producer_producer'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.foo_producer_producer');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.foo_connection');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.foo_producer');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                    [
-                        [
-                            'name'        => 'foo_exchange',
-                            'type'        => 'direct',
-                            'passive'     => true,
-                            'durable'     => false,
-                            'auto_delete' => true,
-                            'internal'    => true,
-                            'nowait'      => true,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setQueueOptions',
-                    [
-                        [
-                            'name'        => '',
-                            'declare'     => false,
-                        ],
-                    ],
-                ],
-                [
-                    'setDefaultRoutingKey',
-                    [''],
-                ],
-                [
-                    'setContentType',
-                    ['text/plain'],
-                ],
-                [
-                    'setDeliveryMode',
-                    [2],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('My\Foo\Producer', $definition->getClass());
-    }
-
-    public function testProducerArgumentAliases()
-    {
-        /** @var ContainerBuilder $container */
-        $container = $this->getContainer('test.yml');
-
-        if (!method_exists($container, 'registerAliasForArgument')) {
-            // don't test if autowiring arguments functionality is not available
-            return;
-        }
-
-        // test expected aliases
-        $expectedAliases = [
-            ProducerInterface::class . ' $fooProducer' => 'old_sound_rabbit_mq.foo_producer_producer',
-            'My\Foo\Producer $fooProducer' => 'old_sound_rabbit_mq.foo_producer_producer',
-            ProducerInterface::class . ' $fooProducerAliasedProducer' => 'old_sound_rabbit_mq.foo_producer_aliased_producer',
-            'My\Foo\Producer $fooProducerAliasedProducer' => 'old_sound_rabbit_mq.foo_producer_aliased_producer',
-            ProducerInterface::class . ' $defaultProducer' => 'old_sound_rabbit_mq.default_producer_producer',
-            '%old_sound_rabbit_mq.producer.class% $defaultProducer' => 'old_sound_rabbit_mq.default_producer_producer',
-        ];
-
-        foreach ($expectedAliases as $id => $target) {
-            $this->assertTrue($container->hasAlias($id), sprintf('Container should have %s alias for autowiring support.', $id));
-
-            $alias = $container->getAlias($id);
-            $this->assertEquals($target, (string)$alias, sprintf('Autowiring for %s should use %s.', $id, $target));
-            $this->assertFalse($alias->isPublic(), sprintf('Autowiring alias for %s should be private', $id));
-        }
-    }
-
-    /**
-     * @group alias
-     */
-    public function testAliasedFooProducerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_producer_producer'));
-        $this->assertTrue($container->has('foo_producer_alias'));
-    }
-
-    public function testDefaultProducerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.default_producer_producer'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.default_producer_producer');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.default_producer');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                    [
-                        [
-                            'name'        => 'default_exchange',
-                            'type'        => 'direct',
-                            'passive'     => false,
-                            'durable'     => true,
-                            'auto_delete' => false,
-                            'internal'    => false,
-                            'nowait'      => false,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setQueueOptions',
-                    [
-                        [
-                            'name'        => '',
-                            'declare'     => false,
-                        ],
-                    ],
-                ],
-                [
-                    'setDefaultRoutingKey',
-                    [''],
-                ],
-                [
-                    'setContentType',
-                    ['text/plain'],
-                ],
-                [
-                    'setDeliveryMode',
-                    [2],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.producer.class%', $definition->getClass());
-    }
-
-    public function testFooConsumerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_consumer_consumer'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.foo_consumer_consumer');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.foo_connection');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.foo_consumer');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                    [
-                        [
-                            'name'        => 'foo_exchange',
-                            'type'        => 'direct',
-                            'passive'     => true,
-                            'durable'     => false,
-                            'auto_delete' => true,
-                            'internal'    => true,
-                            'nowait'      => true,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setQueueOptions',
-                    [
-                        [
-                            'name'         => 'foo_queue',
-                            'passive'      => true,
-                            'durable'      => false,
-                            'exclusive'    => true,
-                            'auto_delete'  => true,
-                            'nowait'       => true,
-                            'arguments'    => null,
-                            'ticket'       => null,
-                            'routing_keys' => ['android.#.upload', 'iphone.upload'],
-                            'declare'      => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setCallback',
-                    [[new Reference('foo.callback'), 'execute']],
-                ],
-                [
-                    'setTimeoutWait',
-                    [3],
-                ],
-                [
-                    'setConsumerOptions',
-                    [
-                        [
-                            'no_ack' => true,
-                        ],
-                    ],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.consumer.class%', $definition->getClass());
-    }
-
-    public function testConsumerArgumentAliases()
-    {
-        /** @var ContainerBuilder $container */
-        $container = $this->getContainer('test.yml');
-
-        if (!method_exists($container, 'registerAliasForArgument')) {
-            // don't test if autowiring arguments functionality is not available
-            return;
-        }
-
-        $expectedAliases = [
-            ConsumerInterface::class . ' $fooConsumer' => 'old_sound_rabbit_mq.foo_consumer_consumer',
-            '%old_sound_rabbit_mq.consumer.class% $fooConsumer' => 'old_sound_rabbit_mq.foo_consumer_consumer',
-            ConsumerInterface::class . ' $defaultConsumer' => 'old_sound_rabbit_mq.default_consumer_consumer',
-            '%old_sound_rabbit_mq.consumer.class% $defaultConsumer' => 'old_sound_rabbit_mq.default_consumer_consumer',
-            ConsumerInterface::class . ' $qosTestConsumer' => 'old_sound_rabbit_mq.qos_test_consumer_consumer',
-            '%old_sound_rabbit_mq.consumer.class% $qosTestConsumer' => 'old_sound_rabbit_mq.qos_test_consumer_consumer',
-        ];
-        foreach ($expectedAliases as $id => $target) {
-            $this->assertTrue($container->hasAlias($id), sprintf('Container should have %s alias for autowiring support.', $id));
-
-            $alias = $container->getAlias($id);
-            $this->assertEquals($target, (string)$alias, sprintf('Autowiring for %s should use %s.', $id, $target));
-            $this->assertFalse($alias->isPublic(), sprintf('Autowiring alias for %s should be private', $id));
-        }
-    }
-
-    public function testDefaultConsumerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.default_consumer_consumer'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.default_consumer_consumer');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.default_consumer');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                    [
-                        [
-                            'name'        => 'default_exchange',
-                            'type'        => 'direct',
-                            'passive'     => false,
-                            'durable'     => true,
-                            'auto_delete' => false,
-                            'internal'    => false,
-                            'nowait'      => false,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setQueueOptions',
-                    [
-                        [
-                            'name'        => 'default_queue',
-                            'passive'     => false,
-                            'durable'     => true,
-                            'exclusive'   => false,
-                            'auto_delete' => false,
-                            'nowait'      => false,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'routing_keys' => [],
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setCallback',
-                    [[new Reference('default.callback'), 'execute']],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.consumer.class%', $definition->getClass());
-    }
-
-    public function testConsumerWithQosOptions()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.qos_test_consumer_consumer'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.qos_test_consumer_consumer');
-        $methodCalls = $definition->getMethodCalls();
-
-        $setQosParameters = null;
-        foreach ($methodCalls as $methodCall) {
-            if ($methodCall[0] === 'setQosOptions') {
-                $setQosParameters = $methodCall[1];
-            }
-        }
-
-        $this->assertIsArray($setQosParameters);
-        $this->assertEquals(
-            [
-                1024,
-                1,
-                true,
-            ],
-            $setQosParameters
-        );
-    }
-
-    public function testMultipleConsumerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.multi_test_consumer_multiple'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.multi_test_consumer_multiple');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                    [
-                        [
-                            'name'        => 'foo_multiple_exchange',
-                            'type'        => 'direct',
-                            'passive'     => false,
-                            'durable'     => true,
-                            'auto_delete' => false,
-                            'internal'    => false,
-                            'nowait'      => false,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setQueues',
-                    [
-                        [
-                            'multi_test_1' => [
-                                'name'         => 'multi_test_1',
-                                'passive'      => false,
-                                'durable'      => true,
-                                'exclusive'    => false,
-                                'auto_delete'  => false,
-                                'nowait'       => false,
-                                'arguments'    => null,
-                                'ticket'       => null,
-                                'routing_keys' => [],
-                                'callback'     => [new Reference('foo.multiple_test1.callback'), 'execute'],
-                                'declare'      => true,
-                            ],
-                            'foo_bar_2' => [
-                                'name'         => 'foo_bar_2',
-                                'passive'      => true,
-                                'durable'      => false,
-                                'exclusive'    => true,
-                                'auto_delete'  => true,
-                                'nowait'       => true,
-                                'arguments'    => null,
-                                'ticket'       => null,
-                                'routing_keys' => [
-                                    'android.upload',
-                                    'iphone.upload',
-                                ],
-                                'callback'     => [new Reference('foo.multiple_test2.callback'), 'execute'],
-                                'declare'      => true,
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'setQueuesProvider',
-                    [
-                        new Reference('foo.queues_provider'),
-                    ],
-                ],
-                [
-                    'setTimeoutWait',
-                    [3],
-                ],
-                [
-                    'setConsumerOptions',
-                    [
-                        [
-                            'no_ack' => true,
-                        ],
-                    ],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-    }
-
-    public function testDynamicConsumerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_dyn_consumer_dynamic'));
-        $this->assertTrue($container->has('old_sound_rabbit_mq.bar_dyn_consumer_dynamic'));
-
-        $definition = $container->getDefinition('old_sound_rabbit_mq.foo_dyn_consumer_dynamic');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                        [
-                            [
-                                'name' => 'foo_dynamic_exchange',
-                                'type' => 'direct',
-                                'passive' => false,
-                                'durable' => true,
-                                'auto_delete' => false,
-                                'internal' => false,
-                                'nowait' => false,
-                                'declare' => true,
-                                'arguments' => null,
-                                'ticket' => null,
-                            ],
-                        ],
-                ],
-                [
-                    'setCallback',
-                        [
-                            [new Reference('foo.dynamic.callback'), 'execute'],
-                        ],
-                ],
-                [
-                    'setQueueOptionsProvider',
-                        [
-                            new Reference('foo.dynamic.provider'),
-                        ],
-                ],
-                [
-                    'setConsumerOptions',
-                    [
-                        [
-                            'no_ack' => true,
-                        ],
-                    ],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-    }
-
-    public function testFooAnonConsumerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_anon_consumer_anon'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.foo_anon_consumer_anon');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.foo_connection');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.foo_anon_consumer');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                    [
-                        [
-                            'name'        => 'foo_anon_exchange',
-                            'type'        => 'direct',
-                            'passive'     => true,
-                            'durable'     => false,
-                            'auto_delete' => true,
-                            'internal'    => true,
-                            'nowait'      => true,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setCallback',
-                    [[new Reference('foo_anon.callback'), 'execute']],
-                ],
-                [
-                    'setConsumerOptions',
-                    [
-                        [
-                            'no_ack' => true,
-                        ],
-                    ],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.anon_consumer.class%', $definition->getClass());
-    }
-
-    public function testDefaultAnonConsumerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.default_anon_consumer_anon'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.default_anon_consumer_anon');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.default_anon_consumer');
-        $this->assertEquals(
-            [
-                [
-                    'setExchangeOptions',
-                    [
-                        [
-                            'name'        => 'default_anon_exchange',
-                            'type'        => 'direct',
-                            'passive'     => false,
-                            'durable'     => true,
-                            'auto_delete' => false,
-                            'internal'    => false,
-                            'nowait'      => false,
-                            'arguments'   => null,
-                            'ticket'      => null,
-                            'declare'     => true,
-                        ],
-                    ],
-                ],
-                [
-                    'setCallback',
-                    [[new Reference('default_anon.callback'), 'execute']],
-                ],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.anon_consumer.class%', $definition->getClass());
-    }
-
-    public function testFooRpcClientDefinition()
-    {
-        $container = $this->getContainer('rpc-clients.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_client_rpc'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.foo_client_rpc');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.foo_connection');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.foo_client');
-        $this->assertEquals(
-            [
-                ['initClient', [true]],
-                ['setUnserializer', ['json_decode']],
-                ['setDirectReplyTo', [true]],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.rpc_client.class%', $definition->getClass());
-    }
-
-    public function testDefaultRpcClientDefinition()
-    {
-        $container = $this->getContainer('rpc-clients.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.default_client_rpc'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.default_client_rpc');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.default_client');
-        $this->assertEquals(
-            [
-                ['initClient', [true]],
-                ['setUnserializer', ['unserialize']],
-                ['setDirectReplyTo', [false]],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertFalse($definition->isLazy());
-        $this->assertEquals('%old_sound_rabbit_mq.rpc_client.class%', $definition->getClass());
-    }
-
-    public function testLazyRpcClientDefinition()
-    {
-        $container = $this->getContainer('rpc-clients.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.lazy_client_rpc'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.lazy_client_rpc');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.lazy_client');
-        $this->assertEquals(
-            [
-                ['initClient', [true]],
-                ['setUnserializer', ['unserialize']],
-                ['setDirectReplyTo', [false]],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertTrue($definition->isLazy());
-        $this->assertEquals('%old_sound_rabbit_mq.rpc_client.class%', $definition->getClass());
-    }
-
-    public function testFooRpcServerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.foo_server_server'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.foo_server_server');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.foo_connection');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.foo_server');
-        $this->assertEquals(
-            [
-                ['initServer', ['foo_server']],
-                ['setCallback', [[new Reference('foo_server.callback'), 'execute']]],
-                ['setSerializer', ['json_encode']],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.rpc_server.class%', $definition->getClass());
-    }
-
-    public function testDefaultRpcServerDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.default_server_server'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.default_server_server');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.default_server');
-        $this->assertEquals(
-            [
-                ['initServer', ['default_server']],
-                ['setCallback', [[new Reference('default_server.callback'), 'execute']]],
-                ['setSerializer', ['serialize']],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.rpc_server.class%', $definition->getClass());
-    }
-
-    public function testRpcServerWithQueueOptionsDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.server_with_queue_options_server'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.server_with_queue_options_server');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.server_with_queue_options');
-        $this->assertEquals(
-            [
-                ['initServer', ['server_with_queue_options']],
-                ['setCallback', [[new Reference('server_with_queue_options.callback'), 'execute']]],
-                ['setQueueOptions', [[
-                    'name'         => 'server_with_queue_options-queue',
-                    'passive'      => false,
-                    'durable'      => true,
-                    'exclusive'    => false,
-                    'auto_delete'  => false,
-                    'nowait'       => false,
-                    'arguments'    => null,
-                    'ticket'       => null,
-                    'routing_keys' => [],
-                    'declare'      => true,
-                ]]],
-                ['setSerializer', ['serialize']],
-            ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.rpc_server.class%', $definition->getClass());
-    }
-
-    public function testRpcServerWithExchangeOptionsDefinition()
-    {
-        $container = $this->getContainer('test.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.server_with_exchange_options_server'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.server_with_exchange_options_server');
-        $this->assertEquals((string) $definition->getArgument(0), 'old_sound_rabbit_mq.connection.default');
-        $this->assertEquals((string) $definition->getArgument(1), 'old_sound_rabbit_mq.channel.server_with_exchange_options');
-        $this->assertEquals(
-            [
-            ['initServer', ['server_with_exchange_options']],
-            ['setCallback', [[new Reference('server_with_exchange_options.callback'), 'execute']]],
-            ['setExchangeOptions', [[
-                'name'         => 'exchange',
-                'type'         => 'topic',
-                'passive'      => false,
-                'durable'      => true,
-                'auto_delete'  => false,
-                'internal'     => null,
-                'nowait'       => false,
-                'declare'      => true,
-                'arguments'    => null,
-                'ticket'       => null,
-            ]]],
-            ['setSerializer', ['serialize']],
-        ],
-            $definition->getMethodCalls()
-        );
-        $this->assertEquals('%old_sound_rabbit_mq.rpc_server.class%', $definition->getClass());
-    }
-
-    public function testHasCollectorWhenChannelsExist()
-    {
-        $container = $this->getContainer('collector.yml');
-
-        $this->assertTrue($container->has('old_sound_rabbit_mq.data_collector'));
-        $definition = $container->getDefinition('old_sound_rabbit_mq.data_collector');
-
-        $this->assertEquals(
-            [
-                new Reference('old_sound_rabbit_mq.channel.default_producer'),
-                new Reference('old_sound_rabbit_mq.channel.default_consumer'),
-            ],
-            $definition->getArgument(0)
-        );
-    }
-
-    public function testHasNoCollectorWhenNoChannelsExist()
-    {
-        $container = $this->getContainer('no_collector.yml');
-        $this->assertFalse($container->has('old_sound_rabbit_mq.data_collector'));
-    }
-
-    public function testCollectorCanBeDisabled()
-    {
-        $container = $this->getContainer('collector_disabled.yml');
-        $this->assertFalse($container->has('old_sound_rabbit_mq.data_collector'));
-    }
-
-    public function testExchangeArgumentsAreArray()
-    {
-        $container = $this->getContainer('exchange_arguments.yml');
-
-        $definition = $container->getDefinition('old_sound_rabbit_mq.producer_producer');
-        $calls = $definition->getMethodCalls();
-        $this->assertEquals('setExchangeOptions', $calls[0][0]);
-        $options = $calls[0][1];
-        $this->assertEquals(['name' => 'bar'], $options[0]['arguments']);
-
-        $definition = $container->getDefinition('old_sound_rabbit_mq.consumer_consumer');
-        $calls = $definition->getMethodCalls();
-        $this->assertEquals('setExchangeOptions', $calls[0][0]);
-        $options = $calls[0][1];
-        $this->assertEquals(['name' => 'bar'], $options[0]['arguments']);
-    }
-
-    public function testProducerWithoutExplicitExchangeOptionsConnectsToAMQPDefault()
-    {
-        $container = $this->getContainer('no_exchange_options.yml');
-
-        $definition = $container->getDefinition('old_sound_rabbit_mq.producer_producer');
-        $calls = $definition->getMethodCalls();
-        $this->assertEquals('setExchangeOptions', $calls[0][0]);
-        $options = $calls[0][1];
-
-        $this->assertEquals('', $options[0]['name']);
-        $this->assertEquals('direct', $options[0]['type']);
-        $this->assertEquals(false, $options[0]['declare']);
-        $this->assertEquals(true, $options[0]['passive']);
-    }
-
-    public function testProducersWithLogger()
-    {
-        $container = $this->getContainer('config_with_enable_logger.yml');
-        $definition = $container->getDefinition('old_sound_rabbit_mq.default_consumer_consumer');
-        $this->assertTrue(
-            $definition->hasTag('monolog.logger'),
-            'service should be marked for logger'
-        );
-    }
-
-    private function getContainer($file, $debug = false)
-    {
-        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => $debug]));
-        $container->registerExtension(new OldSoundRabbitMqExtension());
-
-        $locator = new FileLocator(__DIR__.'/Fixtures');
-        $loader = new YamlFileLoader($container, $locator);
-        $loader->load($file);
-
-        $container->getCompilerPassConfig()->setOptimizationPasses([]);
-        $container->getCompilerPassConfig()->setRemovingPasses([]);
-        $container->compile();
-
-        return $container;
-    }
+    return $container;
 }
+
+function assertBindingMethodCallsEqual(Definition $definition, array $binding): void
+{
+    expect($definition->getMethodCalls())->toEqual([
+        ['setArguments',           [$binding['arguments']]],
+        ['setDestination',         [$binding['destination']]],
+        ['setDestinationIsExchange', [$binding['destination_is_exchange']]],
+        ['setExchange',            [$binding['exchange']]],
+        ['isNowait',               [$binding['nowait']]],
+        ['setRoutingKey',          [$binding['routing_key']]],
+    ]);
+}
+
+test('foo connection definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.connection.foo_connection');
+    $factory    = $container->getDefinition('old_sound_rabbit_mq.connection_factory.foo_connection');
+
+    expect($container->has('old_sound_rabbit_mq.connection.foo_connection'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.connection_factory.foo_connection'))->toBeTrue();
+    expect($definition->getFactory())->toEqual(['old_sound_rabbit_mq.connection_factory.foo_connection', 'createConnection']);
+    expect($factory->getArgument(1))->toEqual([
+        'host' => 'foo_host', 'port' => 123, 'user' => 'foo_user', 'password' => 'foo_password',
+        'vhost' => '/foo', 'lazy' => false, 'connection_timeout' => 3, 'read_write_timeout' => 3,
+        'ssl_context' => [], 'keepalive' => false, 'heartbeat' => 0, 'use_socket' => false,
+        'url' => '', 'hosts' => [], 'channel_rpc_timeout' => 0.0, 'login_method' => 'AMQPLAIN',
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.connection.class%');
+});
+
+test('ssl connection definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.connection.ssl_connection');
+    $factory    = $container->getDefinition('old_sound_rabbit_mq.connection_factory.ssl_connection');
+
+    expect($container->has('old_sound_rabbit_mq.connection.ssl_connection'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.connection_factory.ssl_connection'))->toBeTrue();
+    expect($definition->getFactory())->toEqual(['old_sound_rabbit_mq.connection_factory.ssl_connection', 'createConnection']);
+    expect($factory->getArgument(1))->toEqual([
+        'host' => 'ssl_host', 'port' => 123, 'user' => 'ssl_user', 'password' => 'ssl_password',
+        'vhost' => '/ssl', 'lazy' => false, 'connection_timeout' => 3, 'read_write_timeout' => 3,
+        'ssl_context' => ['verify_peer' => false], 'keepalive' => false, 'heartbeat' => 0, 'use_socket' => false,
+        'url' => '', 'hosts' => [], 'channel_rpc_timeout' => 0.0, 'login_method' => 'AMQPLAIN',
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.connection.class%');
+});
+
+test('lazy connection definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.connection.lazy_connection');
+    $factory    = $container->getDefinition('old_sound_rabbit_mq.connection_factory.lazy_connection');
+
+    expect($container->has('old_sound_rabbit_mq.connection.lazy_connection'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.connection_factory.lazy_connection'))->toBeTrue();
+    expect($definition->getFactory())->toEqual(['old_sound_rabbit_mq.connection_factory.lazy_connection', 'createConnection']);
+    expect($factory->getArgument(1))->toEqual([
+        'host' => 'lazy_host', 'port' => 456, 'user' => 'lazy_user', 'password' => 'lazy_password',
+        'vhost' => '/lazy', 'lazy' => true, 'connection_timeout' => 3, 'read_write_timeout' => 3,
+        'ssl_context' => [], 'keepalive' => false, 'heartbeat' => 0, 'use_socket' => false,
+        'url' => '', 'hosts' => [], 'channel_rpc_timeout' => 0.0, 'login_method' => 'AMQPLAIN',
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.lazy.connection.class%');
+});
+
+test('default connection definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.connection.default');
+    $factory    = $container->getDefinition('old_sound_rabbit_mq.connection_factory.default');
+
+    expect($container->has('old_sound_rabbit_mq.connection.default'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.connection_factory.default'))->toBeTrue();
+    expect($definition->getFactory())->toEqual(['old_sound_rabbit_mq.connection_factory.default', 'createConnection']);
+    expect($factory->getArgument(1))->toEqual([
+        'host' => 'localhost', 'port' => 5672, 'user' => 'guest', 'password' => 'guest',
+        'vhost' => '/', 'lazy' => false, 'connection_timeout' => 3, 'read_write_timeout' => 3,
+        'ssl_context' => [], 'keepalive' => false, 'heartbeat' => 0, 'use_socket' => false,
+        'url' => '', 'hosts' => [], 'channel_rpc_timeout' => 0.0, 'login_method' => 'AMQPLAIN',
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.connection.class%');
+});
+
+test('socket connection definition', function () {
+    $container = buildContainer('test.yml');
+
+    expect($container->has('old_sound_rabbit_mq.connection.socket_connection'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.connection_factory.socket_connection'))->toBeTrue();
+    expect($container->getDefinition('old_sound_rabbit_mq.connection.socket_connection')->getClass())
+        ->toBe('%old_sound_rabbit_mq.socket_connection.class%');
+});
+
+test('lazy socket connection definition', function () {
+    $container = buildContainer('test.yml');
+
+    expect($container->has('old_sound_rabbit_mq.connection.lazy_socket'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.connection_factory.lazy_socket'))->toBeTrue();
+    expect($container->getDefinition('old_sound_rabbit_mq.connection.lazy_socket')->getClass())
+        ->toBe('%old_sound_rabbit_mq.lazy.socket_connection.class%');
+});
+
+test('cluster connection definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.connection.cluster_connection');
+    $factory    = $container->getDefinition('old_sound_rabbit_mq.connection_factory.cluster_connection');
+
+    expect($container->has('old_sound_rabbit_mq.connection.cluster_connection'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.connection_factory.cluster_connection'))->toBeTrue();
+    expect($definition->getFactory())->toEqual(['old_sound_rabbit_mq.connection_factory.cluster_connection', 'createConnection']);
+    expect($factory->getArgument(1))->toEqual([
+        'hosts' => [
+            ['host' => 'cluster_host', 'port' => 111, 'user' => 'cluster_user', 'password' => 'cluster_password', 'vhost' => '/cluster', 'url' => ''],
+            ['host' => 'localhost', 'port' => 5672, 'user' => 'guest', 'password' => 'guest', 'vhost' => '/', 'url' => 'amqp://cluster_url_host:cluster_url_pass@host:10000/cluster_url_vhost'],
+        ],
+        'host' => 'localhost', 'port' => 5672, 'user' => 'guest', 'password' => 'guest', 'vhost' => '/',
+        'lazy' => false, 'connection_timeout' => 3, 'read_write_timeout' => 3, 'ssl_context' => [],
+        'keepalive' => false, 'heartbeat' => 0, 'use_socket' => false, 'url' => '',
+        'channel_rpc_timeout' => 0.0, 'login_method' => 'AMQPLAIN',
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.connection.class%');
+});
+
+test('foo binding definition', function () {
+    $container = buildContainer('test.yml');
+    $binding   = [
+        'arguments'               => null,
+        'class'                   => '%old_sound_rabbit_mq.binding.class%',
+        'connection'              => 'default',
+        'exchange'                => 'foo',
+        'destination'             => 'bar',
+        'destination_is_exchange' => false,
+        'nowait'                  => false,
+        'routing_key'             => 'baz',
+    ];
+    ksort($binding);
+    $name = sprintf('old_sound_rabbit_mq.binding.%s', md5(json_encode($binding)));
+
+    expect($container->has($name))->toBeTrue();
+
+    $definition = $container->getDefinition($name);
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    assertBindingMethodCallsEqual($definition, $binding);
+});
+
+test('moo binding definition', function () {
+    $container = buildContainer('test.yml');
+    $binding   = [
+        'arguments'               => ['moo' => 'cow'],
+        'class'                   => '%old_sound_rabbit_mq.binding.class%',
+        'connection'              => 'default2',
+        'exchange'                => 'moo',
+        'destination'             => 'cow',
+        'destination_is_exchange' => true,
+        'nowait'                  => true,
+        'routing_key'             => null,
+    ];
+    ksort($binding);
+    $name = sprintf('old_sound_rabbit_mq.binding.%s', md5(json_encode($binding)));
+
+    expect($container->has($name))->toBeTrue();
+
+    $definition = $container->getDefinition($name);
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default2');
+    assertBindingMethodCallsEqual($definition, $binding);
+});
+
+test('foo producer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.foo_producer_producer');
+
+    expect($container->has('old_sound_rabbit_mq.foo_producer_producer'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.foo_connection');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.foo_producer');
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'foo_exchange', 'type' => 'direct', 'passive' => true, 'durable' => false, 'auto_delete' => true, 'internal' => true, 'nowait' => true, 'arguments' => null, 'ticket' => null, 'declare' => true]]],
+        ['setQueueOptions', [['name' => '', 'declare' => false]]],
+        ['setDefaultRoutingKey', ['']],
+        ['setContentType', ['text/plain']],
+        ['setDeliveryMode', [2]],
+    ]);
+    expect($definition->getClass())->toBe('My\Foo\Producer');
+});
+
+test('producer argument aliases', function () {
+    $container = buildContainer('test.yml');
+
+    if (!method_exists($container, 'registerAliasForArgument')) {
+        return;
+    }
+
+    $expectedAliases = [
+        ProducerInterface::class . ' $fooProducer'              => 'old_sound_rabbit_mq.foo_producer_producer',
+        'My\Foo\Producer $fooProducer'                          => 'old_sound_rabbit_mq.foo_producer_producer',
+        ProducerInterface::class . ' $fooProducerAliasedProducer' => 'old_sound_rabbit_mq.foo_producer_aliased_producer',
+        'My\Foo\Producer $fooProducerAliasedProducer'           => 'old_sound_rabbit_mq.foo_producer_aliased_producer',
+        ProducerInterface::class . ' $defaultProducer'          => 'old_sound_rabbit_mq.default_producer_producer',
+        '%old_sound_rabbit_mq.producer.class% $defaultProducer' => 'old_sound_rabbit_mq.default_producer_producer',
+    ];
+
+    foreach ($expectedAliases as $id => $target) {
+        expect($container->hasAlias($id))->toBeTrue("Container should have $id alias for autowiring support.");
+        $alias = $container->getAlias($id);
+        expect((string) $alias)->toBe($target, "Autowiring for $id should use $target.");
+        expect($alias->isPublic())->toBeFalse("Autowiring alias for $id should be private.");
+    }
+});
+
+test('aliased foo producer definition', function () {
+    $container = buildContainer('test.yml');
+
+    expect($container->has('old_sound_rabbit_mq.foo_producer_producer'))->toBeTrue();
+    expect($container->has('foo_producer_alias'))->toBeTrue();
+})->group('alias');
+
+test('default producer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.default_producer_producer');
+
+    expect($container->has('old_sound_rabbit_mq.default_producer_producer'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.default_producer');
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'default_exchange', 'type' => 'direct', 'passive' => false, 'durable' => true, 'auto_delete' => false, 'internal' => false, 'nowait' => false, 'arguments' => null, 'ticket' => null, 'declare' => true]]],
+        ['setQueueOptions', [['name' => '', 'declare' => false]]],
+        ['setDefaultRoutingKey', ['']],
+        ['setContentType', ['text/plain']],
+        ['setDeliveryMode', [2]],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.producer.class%');
+});
+
+test('foo consumer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.foo_consumer_consumer');
+
+    expect($container->has('old_sound_rabbit_mq.foo_consumer_consumer'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.foo_connection');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.foo_consumer');
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'foo_exchange', 'type' => 'direct', 'passive' => true, 'durable' => false, 'auto_delete' => true, 'internal' => true, 'nowait' => true, 'arguments' => null, 'ticket' => null, 'declare' => true]]],
+        ['setQueueOptions', [['name' => 'foo_queue', 'passive' => true, 'durable' => false, 'exclusive' => true, 'auto_delete' => true, 'nowait' => true, 'arguments' => null, 'ticket' => null, 'routing_keys' => ['android.#.upload', 'iphone.upload'], 'declare' => true]]],
+        ['setCallback', [[new Reference('foo.callback'), 'execute']]],
+        ['setTimeoutWait', [3]],
+        ['setConsumerOptions', [['no_ack' => true]]],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.consumer.class%');
+});
+
+test('consumer argument aliases', function () {
+    $container = buildContainer('test.yml');
+
+    if (!method_exists($container, 'registerAliasForArgument')) {
+        return;
+    }
+
+    $expectedAliases = [
+        ConsumerInterface::class . ' $fooConsumer'                        => 'old_sound_rabbit_mq.foo_consumer_consumer',
+        '%old_sound_rabbit_mq.consumer.class% $fooConsumer'               => 'old_sound_rabbit_mq.foo_consumer_consumer',
+        ConsumerInterface::class . ' $defaultConsumer'                    => 'old_sound_rabbit_mq.default_consumer_consumer',
+        '%old_sound_rabbit_mq.consumer.class% $defaultConsumer'           => 'old_sound_rabbit_mq.default_consumer_consumer',
+        ConsumerInterface::class . ' $qosTestConsumer'                    => 'old_sound_rabbit_mq.qos_test_consumer_consumer',
+        '%old_sound_rabbit_mq.consumer.class% $qosTestConsumer'           => 'old_sound_rabbit_mq.qos_test_consumer_consumer',
+    ];
+
+    foreach ($expectedAliases as $id => $target) {
+        expect($container->hasAlias($id))->toBeTrue("Container should have $id alias for autowiring support.");
+        $alias = $container->getAlias($id);
+        expect((string) $alias)->toBe($target, "Autowiring for $id should use $target.");
+        expect($alias->isPublic())->toBeFalse("Autowiring alias for $id should be private.");
+    }
+});
+
+test('default consumer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.default_consumer_consumer');
+
+    expect($container->has('old_sound_rabbit_mq.default_consumer_consumer'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.default_consumer');
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'default_exchange', 'type' => 'direct', 'passive' => false, 'durable' => true, 'auto_delete' => false, 'internal' => false, 'nowait' => false, 'arguments' => null, 'ticket' => null, 'declare' => true]]],
+        ['setQueueOptions', [['name' => 'default_queue', 'passive' => false, 'durable' => true, 'exclusive' => false, 'auto_delete' => false, 'nowait' => false, 'arguments' => null, 'ticket' => null, 'routing_keys' => [], 'declare' => true]]],
+        ['setCallback', [[new Reference('default.callback'), 'execute']]],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.consumer.class%');
+});
+
+test('consumer with QOS options', function () {
+    $container    = buildContainer('test.yml');
+    $definition   = $container->getDefinition('old_sound_rabbit_mq.qos_test_consumer_consumer');
+    $methodCalls  = $definition->getMethodCalls();
+
+    $setQosParameters = null;
+    foreach ($methodCalls as $methodCall) {
+        if ($methodCall[0] === 'setQosOptions') {
+            $setQosParameters = $methodCall[1];
+        }
+    }
+
+    expect($setQosParameters)->toBeArray();
+    expect($setQosParameters)->toEqual([1024, 1, true]);
+});
+
+test('multiple consumer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.multi_test_consumer_multiple');
+
+    expect($container->has('old_sound_rabbit_mq.multi_test_consumer_multiple'))->toBeTrue();
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'foo_multiple_exchange', 'type' => 'direct', 'passive' => false, 'durable' => true, 'auto_delete' => false, 'internal' => false, 'nowait' => false, 'arguments' => null, 'ticket' => null, 'declare' => true]]],
+        ['setQueues', [[
+            'multi_test_1' => ['name' => 'multi_test_1', 'passive' => false, 'durable' => true, 'exclusive' => false, 'auto_delete' => false, 'nowait' => false, 'arguments' => null, 'ticket' => null, 'routing_keys' => [], 'callback' => [new Reference('foo.multiple_test1.callback'), 'execute'], 'declare' => true],
+            'foo_bar_2'    => ['name' => 'foo_bar_2', 'passive' => true, 'durable' => false, 'exclusive' => true, 'auto_delete' => true, 'nowait' => true, 'arguments' => null, 'ticket' => null, 'routing_keys' => ['android.upload', 'iphone.upload'], 'callback' => [new Reference('foo.multiple_test2.callback'), 'execute'], 'declare' => true],
+        ]]],
+        ['setQueuesProvider', [new Reference('foo.queues_provider')]],
+        ['setTimeoutWait', [3]],
+        ['setConsumerOptions', [['no_ack' => true]]],
+    ]);
+});
+
+test('dynamic consumer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.foo_dyn_consumer_dynamic');
+
+    expect($container->has('old_sound_rabbit_mq.foo_dyn_consumer_dynamic'))->toBeTrue();
+    expect($container->has('old_sound_rabbit_mq.bar_dyn_consumer_dynamic'))->toBeTrue();
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'foo_dynamic_exchange', 'type' => 'direct', 'passive' => false, 'durable' => true, 'auto_delete' => false, 'internal' => false, 'nowait' => false, 'declare' => true, 'arguments' => null, 'ticket' => null]]],
+        ['setCallback', [[new Reference('foo.dynamic.callback'), 'execute']]],
+        ['setQueueOptionsProvider', [new Reference('foo.dynamic.provider')]],
+        ['setConsumerOptions', [['no_ack' => true]]],
+    ]);
+});
+
+test('foo anon consumer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.foo_anon_consumer_anon');
+
+    expect($container->has('old_sound_rabbit_mq.foo_anon_consumer_anon'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.foo_connection');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.foo_anon_consumer');
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'foo_anon_exchange', 'type' => 'direct', 'passive' => true, 'durable' => false, 'auto_delete' => true, 'internal' => true, 'nowait' => true, 'arguments' => null, 'ticket' => null, 'declare' => true]]],
+        ['setCallback', [[new Reference('foo_anon.callback'), 'execute']]],
+        ['setConsumerOptions', [['no_ack' => true]]],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.anon_consumer.class%');
+});
+
+test('default anon consumer definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.default_anon_consumer_anon');
+
+    expect($container->has('old_sound_rabbit_mq.default_anon_consumer_anon'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.default_anon_consumer');
+    expect($definition->getMethodCalls())->toEqual([
+        ['setExchangeOptions', [['name' => 'default_anon_exchange', 'type' => 'direct', 'passive' => false, 'durable' => true, 'auto_delete' => false, 'internal' => false, 'nowait' => false, 'arguments' => null, 'ticket' => null, 'declare' => true]]],
+        ['setCallback', [[new Reference('default_anon.callback'), 'execute']]],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.anon_consumer.class%');
+});
+
+test('foo rpc client definition', function () {
+    $container  = buildContainer('rpc-clients.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.foo_client_rpc');
+
+    expect($container->has('old_sound_rabbit_mq.foo_client_rpc'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.foo_connection');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.foo_client');
+    expect($definition->getMethodCalls())->toEqual([
+        ['initClient', [true]],
+        ['setUnserializer', ['json_decode']],
+        ['setDirectReplyTo', [true]],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.rpc_client.class%');
+});
+
+test('default rpc client definition is not lazy', function () {
+    $container  = buildContainer('rpc-clients.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.default_client_rpc');
+
+    expect($container->has('old_sound_rabbit_mq.default_client_rpc'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.default_client');
+    expect($definition->getMethodCalls())->toEqual([
+        ['initClient', [true]],
+        ['setUnserializer', ['unserialize']],
+        ['setDirectReplyTo', [false]],
+    ]);
+    expect($definition->isLazy())->toBeFalse();
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.rpc_client.class%');
+});
+
+test('lazy rpc client definition is lazy', function () {
+    $container  = buildContainer('rpc-clients.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.lazy_client_rpc');
+
+    expect($container->has('old_sound_rabbit_mq.lazy_client_rpc'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.lazy_client');
+    expect($definition->getMethodCalls())->toEqual([
+        ['initClient', [true]],
+        ['setUnserializer', ['unserialize']],
+        ['setDirectReplyTo', [false]],
+    ]);
+    expect($definition->isLazy())->toBeTrue();
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.rpc_client.class%');
+});
+
+test('foo rpc server definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.foo_server_server');
+
+    expect($container->has('old_sound_rabbit_mq.foo_server_server'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.foo_connection');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.foo_server');
+    expect($definition->getMethodCalls())->toEqual([
+        ['initServer', ['foo_server']],
+        ['setCallback', [[new Reference('foo_server.callback'), 'execute']]],
+        ['setSerializer', ['json_encode']],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.rpc_server.class%');
+});
+
+test('default rpc server definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.default_server_server');
+
+    expect($container->has('old_sound_rabbit_mq.default_server_server'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.default_server');
+    expect($definition->getMethodCalls())->toEqual([
+        ['initServer', ['default_server']],
+        ['setCallback', [[new Reference('default_server.callback'), 'execute']]],
+        ['setSerializer', ['serialize']],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.rpc_server.class%');
+});
+
+test('rpc server with queue options definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.server_with_queue_options_server');
+
+    expect($container->has('old_sound_rabbit_mq.server_with_queue_options_server'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.server_with_queue_options');
+    expect($definition->getMethodCalls())->toEqual([
+        ['initServer', ['server_with_queue_options']],
+        ['setCallback', [[new Reference('server_with_queue_options.callback'), 'execute']]],
+        ['setQueueOptions', [[
+            'name' => 'server_with_queue_options-queue', 'passive' => false, 'durable' => true,
+            'exclusive' => false, 'auto_delete' => false, 'nowait' => false, 'arguments' => null,
+            'ticket' => null, 'routing_keys' => [], 'declare' => true,
+        ]]],
+        ['setSerializer', ['serialize']],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.rpc_server.class%');
+});
+
+test('rpc server with exchange options definition', function () {
+    $container  = buildContainer('test.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.server_with_exchange_options_server');
+
+    expect($container->has('old_sound_rabbit_mq.server_with_exchange_options_server'))->toBeTrue();
+    expect((string) $definition->getArgument(0))->toBe('old_sound_rabbit_mq.connection.default');
+    expect((string) $definition->getArgument(1))->toBe('old_sound_rabbit_mq.channel.server_with_exchange_options');
+    expect($definition->getMethodCalls())->toEqual([
+        ['initServer', ['server_with_exchange_options']],
+        ['setCallback', [[new Reference('server_with_exchange_options.callback'), 'execute']]],
+        ['setExchangeOptions', [[
+            'name' => 'exchange', 'type' => 'topic', 'passive' => false, 'durable' => true,
+            'auto_delete' => false, 'internal' => null, 'nowait' => false, 'declare' => true,
+            'arguments' => null, 'ticket' => null,
+        ]]],
+        ['setSerializer', ['serialize']],
+    ]);
+    expect($definition->getClass())->toBe('%old_sound_rabbit_mq.rpc_server.class%');
+});
+
+test('data collector is registered when channels exist', function () {
+    $container  = buildContainer('collector.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.data_collector');
+
+    expect($container->has('old_sound_rabbit_mq.data_collector'))->toBeTrue();
+    expect($definition->getArgument(0))->toEqual([
+        new Reference('old_sound_rabbit_mq.channel.default_producer'),
+        new Reference('old_sound_rabbit_mq.channel.default_consumer'),
+    ]);
+});
+
+test('data collector is not registered when no channels exist', function () {
+    $container = buildContainer('no_collector.yml');
+
+    expect($container->has('old_sound_rabbit_mq.data_collector'))->toBeFalse();
+});
+
+test('data collector can be disabled', function () {
+    $container = buildContainer('collector_disabled.yml');
+
+    expect($container->has('old_sound_rabbit_mq.data_collector'))->toBeFalse();
+});
+
+test('exchange arguments are converted to array', function () {
+    $container = buildContainer('exchange_arguments.yml');
+
+    $producerDefinition = $container->getDefinition('old_sound_rabbit_mq.producer_producer');
+    $producerCalls      = $producerDefinition->getMethodCalls();
+    expect($producerCalls[0][0])->toBe('setExchangeOptions');
+    expect($producerCalls[0][1][0]['arguments'])->toEqual(['name' => 'bar']);
+
+    $consumerDefinition = $container->getDefinition('old_sound_rabbit_mq.consumer_consumer');
+    $consumerCalls      = $consumerDefinition->getMethodCalls();
+    expect($consumerCalls[0][0])->toBe('setExchangeOptions');
+    expect($consumerCalls[0][1][0]['arguments'])->toEqual(['name' => 'bar']);
+});
+
+test('producer without explicit exchange options connects to AMQP default', function () {
+    $container  = buildContainer('no_exchange_options.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.producer_producer');
+    $calls      = $definition->getMethodCalls();
+
+    expect($calls[0][0])->toBe('setExchangeOptions');
+    expect($calls[0][1][0]['name'])->toBe('');
+    expect($calls[0][1][0]['type'])->toBe('direct');
+    expect($calls[0][1][0]['declare'])->toBeFalse();
+    expect($calls[0][1][0]['passive'])->toBeTrue();
+});
+
+test('producers are tagged for monolog logger when enable_logger is configured', function () {
+    $container  = buildContainer('config_with_enable_logger.yml');
+    $definition = $container->getDefinition('old_sound_rabbit_mq.default_consumer_consumer');
+
+    expect($definition->hasTag('monolog.logger'))->toBeTrue();
+});

--- a/Tests/Event/AfterProcessingMessageEventTest.php
+++ b/Tests/Event/AfterProcessingMessageEventTest.php
@@ -1,37 +1,22 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Event;
-
 use OldSound\RabbitMqBundle\Event\AfterProcessingMessageEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Message\AMQPMessage;
-use PHPUnit\Framework\TestCase;
 
-/**
- * Class AfterProcessingMessageEventTest
- *
- * @package OldSound\RabbitMqBundle\Tests\Event
- */
-class AfterProcessingMessageEventTest extends TestCase
-{
-    protected function getConsumer()
-    {
-        return new Consumer(
-            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
-                ->disableOriginalConstructor()
-                ->getMock(),
-            $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-                ->disableOriginalConstructor()
-                ->getMock()
-        );
-    }
+test('event stores the correct message and consumer', function () {
+    $consumer = new Consumer(
+        $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+            ->disableOriginalConstructor()
+            ->getMock(),
+        $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->disableOriginalConstructor()
+            ->getMock()
+    );
 
-    public function testEvent()
-    {
-        $AMQPMessage = new AMQPMessage('body');
-        $consumer = $this->getConsumer();
-        $event = new AfterProcessingMessageEvent($consumer, $AMQPMessage);
-        $this->assertSame($AMQPMessage, $event->getAMQPMessage());
-        $this->assertSame($consumer, $event->getConsumer());
-    }
-}
+    $message = new AMQPMessage('body');
+    $event = new AfterProcessingMessageEvent($consumer, $message);
+
+    expect($event->getAMQPMessage())->toBe($message);
+    expect($event->getConsumer())->toBe($consumer);
+});

--- a/Tests/Event/BeforeProcessingMessageEventTest.php
+++ b/Tests/Event/BeforeProcessingMessageEventTest.php
@@ -1,37 +1,22 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Event;
-
 use OldSound\RabbitMqBundle\Event\BeforeProcessingMessageEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Message\AMQPMessage;
-use PHPUnit\Framework\TestCase;
 
-/**
- * Class BeforeProcessingMessageEventTest
- *
- * @package OldSound\RabbitMqBundle\Tests\Event
- */
-class BeforeProcessingMessageEventTest extends TestCase
-{
-    protected function getConsumer()
-    {
-        return new Consumer(
-            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
-                ->disableOriginalConstructor()
-                ->getMock(),
-            $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-                ->disableOriginalConstructor()
-                ->getMock()
-        );
-    }
+test('event stores the correct message and consumer', function () {
+    $consumer = new Consumer(
+        $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+            ->disableOriginalConstructor()
+            ->getMock(),
+        $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->disableOriginalConstructor()
+            ->getMock()
+    );
 
-    public function testEvent()
-    {
-        $AMQPMessage = new AMQPMessage('body');
-        $consumer = $this->getConsumer();
-        $event = new BeforeProcessingMessageEvent($consumer, $AMQPMessage);
-        $this->assertSame($AMQPMessage, $event->getAMQPMessage());
-        $this->assertSame($consumer, $event->getConsumer());
-    }
-}
+    $message = new AMQPMessage('body');
+    $event = new BeforeProcessingMessageEvent($consumer, $message);
+
+    expect($event->getAMQPMessage())->toBe($message);
+    expect($event->getConsumer())->toBe($consumer);
+});

--- a/Tests/Event/OnIdleEventTest.php
+++ b/Tests/Event/OnIdleEventTest.php
@@ -1,55 +1,36 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Event;
-
 use OldSound\RabbitMqBundle\Event\OnIdleEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
-use PHPUnit\Framework\TestCase;
 
-/**
- * Class OnIdleEventTest
- *
- * @package OldSound\RabbitMqBundle\Tests\Event
- */
-class OnIdleEventTest extends TestCase
-{
-    protected function getConsumer()
-    {
-        return new Consumer(
-            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
-                ->disableOriginalConstructor()
-                ->getMock(),
-            $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-                ->disableOriginalConstructor()
-                ->getMock()
-        );
-    }
+beforeEach(function () {
+    $this->consumer = new Consumer(
+        $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+            ->disableOriginalConstructor()
+            ->getMock(),
+        $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->disableOriginalConstructor()
+            ->getMock()
+    );
+});
 
-    public function testShouldAllowGetConsumerSetInConstructor()
-    {
-        $consumer = $this->getConsumer();
-        $event = new OnIdleEvent($consumer);
+test('should allow get consumer set in constructor', function () {
+    $event = new OnIdleEvent($this->consumer);
 
-        $this->assertSame($consumer, $event->getConsumer());
-    }
+    expect($event->getConsumer())->toBe($this->consumer);
+});
 
-    public function testShouldSetForceStopToTrueInConstructor()
-    {
-        $consumer = $this->getConsumer();
-        $event = new OnIdleEvent($consumer);
+test('should set force stop to true in constructor', function () {
+    $event = new OnIdleEvent($this->consumer);
 
-        $this->assertTrue($event->isForceStop());
-    }
+    expect($event->isForceStop())->toBeTrue();
+});
 
-    public function testShouldReturnPreviouslySetForceStop()
-    {
-        $consumer = $this->getConsumer();
-        $event = new OnIdleEvent($consumer);
+test('should return previously set force stop value', function () {
+    $event = new OnIdleEvent($this->consumer);
 
-        //guard
-        $this->assertTrue($event->isForceStop());
+    expect($event->isForceStop())->toBeTrue();
 
-        $event->setForceStop(false);
-        $this->assertFalse($event->isForceStop());
-    }
-}
+    $event->setForceStop(false);
+    expect($event->isForceStop())->toBeFalse();
+});

--- a/Tests/Manager/MemoryConsumptionCheckerTest.php
+++ b/Tests/Manager/MemoryConsumptionCheckerTest.php
@@ -1,69 +1,40 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\Manager;
-
 use OldSound\RabbitMqBundle\MemoryChecker\MemoryConsumptionChecker;
 use OldSound\RabbitMqBundle\MemoryChecker\NativeMemoryUsageProvider;
-use PHPUnit\Framework\TestCase;
 
-/**
- * Class MemoryManagerTest
- *
- * @package OldSound\RabbitMqBundle\Tests\Manager
- */
-class MemoryConsumptionCheckerTest extends TestCase
-{
-    public function testMemoryIsNotAlmostOverloaded()
-    {
-        $currentMemoryUsage = '7M';
-        $allowedConsumptionUntil = '2M';
-        $maxConsumptionAllowed = '10M';
+test('memory is not almost overloaded when usage is below threshold', function () {
+    $provider = $this->getMockBuilder(NativeMemoryUsageProvider::class)->getMock();
+    $provider->method('getMemoryUsage')->willReturn('7M');
 
-        $memoryUsageProvider = $this->getMockBuilder('OldSound\\RabbitMqBundle\\MemoryChecker\\NativeMemoryUsageProvider')->getMock();
-        $memoryUsageProvider->expects($this->any())->method('getMemoryUsage')->willReturn($currentMemoryUsage);
+    $checker = new MemoryConsumptionChecker($provider);
 
-        $memoryManager = new MemoryConsumptionChecker($memoryUsageProvider);
+    expect($checker->isRamAlmostOverloaded('10M', '2M'))->toBeFalse();
+});
 
-        $this->assertFalse($memoryManager->isRamAlmostOverloaded($maxConsumptionAllowed, $allowedConsumptionUntil));
-    }
+test('memory is almost overloaded when usage is within threshold', function () {
+    $provider = $this->getMockBuilder(NativeMemoryUsageProvider::class)->getMock();
+    $provider->method('getMemoryUsage')->willReturn('9M');
 
-    public function testMemoryIsAlmostOverloaded()
-    {
-        $currentMemoryUsage = '9M';
-        $allowedConsumptionUntil = '2M';
-        $maxConsumptionAllowed = '10M';
+    $checker = new MemoryConsumptionChecker($provider);
 
-        $memoryUsageProvider = $this->getMockBuilder('OldSound\\RabbitMqBundle\\MemoryChecker\\NativeMemoryUsageProvider')->getMock();
-        $memoryUsageProvider->expects($this->any())->method('getMemoryUsage')->willReturn($currentMemoryUsage);
+    expect($checker->isRamAlmostOverloaded('10M', '2M'))->toBeTrue();
+});
 
-        $memoryManager = new MemoryConsumptionChecker($memoryUsageProvider);
+test('memory is not almost overloaded without allowed buffer', function () {
+    $provider = $this->getMockBuilder(NativeMemoryUsageProvider::class)->getMock();
+    $provider->method('getMemoryUsage')->willReturn('7M');
 
-        $this->assertTrue($memoryManager->isRamAlmostOverloaded($maxConsumptionAllowed, $allowedConsumptionUntil));
-    }
+    $checker = new MemoryConsumptionChecker($provider);
 
-    public function testMemoryExactValueIsNotAlmostOverloaded()
-    {
-        $currentMemoryUsage = '7M';
-        $maxConsumptionAllowed = '10M';
+    expect($checker->isRamAlmostOverloaded('10M'))->toBeFalse();
+});
 
-        $memoryUsageProvider = $this->getMockBuilder('OldSound\\RabbitMqBundle\\MemoryChecker\\NativeMemoryUsageProvider')->getMock();
-        $memoryUsageProvider->expects($this->any())->method('getMemoryUsage')->willReturn($currentMemoryUsage);
+test('memory is almost overloaded when usage exceeds max without allowed buffer', function () {
+    $provider = $this->getMockBuilder(NativeMemoryUsageProvider::class)->getMock();
+    $provider->method('getMemoryUsage')->willReturn('11M');
 
-        $memoryManager = new MemoryConsumptionChecker($memoryUsageProvider);
+    $checker = new MemoryConsumptionChecker($provider);
 
-        $this->assertFalse($memoryManager->isRamAlmostOverloaded($maxConsumptionAllowed));
-    }
-
-    public function testMemoryExactValueIsAlmostOverloaded()
-    {
-        $currentMemoryUsage = '11M';
-        $maxConsumptionAllowed = '10M';
-
-        $memoryUsageProvider = $this->getMockBuilder('OldSound\\RabbitMqBundle\\MemoryChecker\\NativeMemoryUsageProvider')->getMock();
-        $memoryUsageProvider->expects($this->any())->method('getMemoryUsage')->willReturn($currentMemoryUsage);
-
-        $memoryManager = new MemoryConsumptionChecker($memoryUsageProvider);
-
-        $this->assertTrue($memoryManager->isRamAlmostOverloaded($maxConsumptionAllowed));
-    }
-}
+    expect($checker->isRamAlmostOverloaded('10M'))->toBeTrue();
+});

--- a/Tests/RabbitMq/AMQPConnectionFactoryTest.php
+++ b/Tests/RabbitMq/AMQPConnectionFactoryTest.php
@@ -1,710 +1,372 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
 use OldSound\RabbitMqBundle\Provider\ConnectionParametersProviderInterface;
 use OldSound\RabbitMqBundle\RabbitMq\AMQPConnectionFactory;
 use OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPConnection;
 use OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSocketConnection;
 use OldSound\RabbitMqBundle\Tests\RabbitMq\Fixtures\AMQPSSLConnection;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
-class AMQPConnectionFactoryTest extends TestCase
-{
-    public function testDefaultValues()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            []
-        );
+test('default connection values', function () {
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, []);
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            'localhost', // host
-            5672,        // port
-            'guest',     // user
-            'guest',     // password
-            '/',         // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            3,           // connection timeout
-            3,           // read write timeout
-            null,        // context
-            false,       // keepalive
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
 
-    public function testSocketConnection()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPSocketConnection::class,
-            []
-        );
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'localhost', 5672, 'guest', 'guest', '/',
+        false, 'AMQPLAIN', null, 'en_US',
+        3, 3, null, false, 0, 0.0,
+    ]);
+});
 
-        /** @var AMQPSocketConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPSocketConnection::class, $instance);
-        $this->assertEquals([
-            'localhost', // host
-            5672,        // port
-            'guest',     // user
-            'guest',     // password
-            '/',         // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            3,           // read_timeout
-            false,       // keepalive
-            3,           // write_timeout
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+test('socket connection default values', function () {
+    $factory = new AMQPConnectionFactory(AMQPSocketConnection::class, []);
 
-    public function testSocketConnectionWithParams()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPSocketConnection::class,
-            [
-                'read_timeout' => 31,
-                'write_timeout' => 32,
-            ]
-        );
+    /** @var AMQPSocketConnection $instance */
+    $instance = $factory->createConnection();
 
-        /** @var AMQPSocketConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPSocketConnection::class, $instance);
-        $this->assertEquals([
-            'localhost', // host
-            5672,        // port
-            'guest',     // user
-            'guest',     // password
-            '/',         // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            31,           // read_timeout
-            false,       // keepalive
-            32,           // write_timeout
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+    expect($instance)->toBeInstanceOf(AMQPSocketConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'localhost', 5672, 'guest', 'guest', '/',
+        false, 'AMQPLAIN', null, 'en_US',
+        3, false, 3, 0, 0.0,
+    ]);
+});
 
-    public function testStandardConnectionParameters()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [
-                'host' => 'foo_host',
-                'port' => 123,
-                'user' => 'foo_user',
-                'password' => 'foo_password',
-                'vhost' => '/vhost',
-            ]
-        );
+test('socket connection with custom timeouts', function () {
+    $factory = new AMQPConnectionFactory(AMQPSocketConnection::class, [
+        'read_timeout' => 31,
+        'write_timeout' => 32,
+    ]);
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            'foo_host',  // host
-            123,         // port
-            'foo_user',  // user
-            'foo_password', // password
-            '/vhost',    // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            3,           // connection timeout
-            3,           // read write timeout
-            null,        // context
-            false,       // keepalive
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+    /** @var AMQPSocketConnection $instance */
+    $instance = $factory->createConnection();
 
-    public function testSetConnectionParametersWithUrl()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [
-                'url' => 'amqp://bar_user:bar_password@bar_host:321/whost?keepalive=1&connection_timeout=6&read_write_timeout=6',
-                'host' => 'foo_host',
-                'port' => 123,
-                'user' => 'foo_user',
-                'password' => 'foo_password',
-                'vhost' => '/vhost',
-            ]
-        );
+    expect($instance)->toBeInstanceOf(AMQPSocketConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'localhost', 5672, 'guest', 'guest', '/',
+        false, 'AMQPLAIN', null, 'en_US',
+        31, false, 32, 0, 0.0,
+    ]);
+});
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            'bar_host',  // host
-            321,         // port
-            'bar_user',  // user
-            'bar_password', // password
-            'whost',     // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            6,           // connection timeout
-            6,           // read write timeout
-            null,        // context
-            true,        // keepalive
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+test('standard connection parameters', function () {
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [
+        'host'     => 'foo_host',
+        'port'     => 123,
+        'user'     => 'foo_user',
+        'password' => 'foo_password',
+        'vhost'    => '/vhost',
+    ]);
 
-    public function testSetConnectionParametersWithUrlEncoded()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [
-                'url' => 'amqp://user%61:%61pass@ho%61st:10000/v%2fhost?keepalive=1&connection_timeout=6&read_write_timeout=6',
-            ]
-        );
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            'hoast',     // host
-            10000,       // port
-            'usera',     // user
-            'apass',     // password
-            'v/host',    // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            6,           // connection timeout
-            6,           // read write timeout
-            null,        // context
-            true,        // keepalive
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'foo_host', 123, 'foo_user', 'foo_password', '/vhost',
+        false, 'AMQPLAIN', null, 'en_US',
+        3, 3, null, false, 0, 0.0,
+    ]);
+});
 
-    public function testSetConnectionParametersWithUrlWithoutVhost()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [
-                'url' => 'amqp://user:pass@host:321/?keepalive=1&connection_timeout=6&read_write_timeout=6',
-            ]
-        );
+test('URL parameters override individual parameters', function () {
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [
+        'url'      => 'amqp://bar_user:bar_password@bar_host:321/whost?keepalive=1&connection_timeout=6&read_write_timeout=6',
+        'host'     => 'foo_host',
+        'port'     => 123,
+        'user'     => 'foo_user',
+        'password' => 'foo_password',
+        'vhost'    => '/vhost',
+    ]);
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            'host',     // host
-            321,        // port
-            'user',     // user
-            'pass',     // password
-            '',         // vhost
-            false,      // insist
-            "AMQPLAIN", // login method
-            null,       // login response
-            "en_US",    // locale
-            6,          // connection timeout
-            6,          // read write timeout
-            null,       // context
-            true,       // keepalive
-            0,          // heartbeat
-            0.0,        //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
 
-    public function testSSLConnectionParameters()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPSSLConnection::class,
-            [
-                'host' => 'ssl_host',
-                'port' => 123,
-                'user' => 'ssl_user',
-                'password' => 'ssl_password',
-                'vhost' => '/ssl',
-                'ssl_context' => [
-                    'verify_peer' => false,
-                ],
-            ]
-        );
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'bar_host', 321, 'bar_user', 'bar_password', 'whost',
+        false, 'AMQPLAIN', null, 'en_US',
+        6, 6, null, true, 0, 0.0,
+    ]);
+});
 
-        /** @var AMQPSSLConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPSSLConnection::class, $instance);
-        $this->assertArrayHasKey(6, $instance->constructParams);
-        $options = $instance->constructParams[6];
-        $this->assertArrayHasKey('ssl_context', $options);
-        $this->assertArrayHasKey('context', $options);
-        $context = $options['context'];
-        // unset to check whole array at once later
-        $instance->constructParams[6]['ssl_context'] = null;
-        $instance->constructParams[6]['context'] = null;
-        $this->assertIsResource($context);
-        $this->assertEquals('stream-context', get_resource_type($context));
-        $options = stream_context_get_options($context);
-        $this->assertEquals(['ssl' => ['verify_peer' => false]], $options);
-        $this->assertEquals([
-            'ssl_host',     // host
-            123,            // port
-            'ssl_user',     // user
-            'ssl_password', // password
-            '/ssl',         // vhost,
-            [],             // ssl_options
-            [               // options
-                'url' => '',
-                'host' => 'ssl_host',
-                'port' => 123,
-                'user' => 'ssl_user',
-                'password' => 'ssl_password',
-                'vhost' => '/ssl',
-                'connection_timeout' => 3,
-                'read_write_timeout' => 3,
-                'ssl_context' => null, // context checked earlier
-                'context' => null, // context checked earlier
-                'keepalive' => false,
-                'heartbeat' => 0,
-                'channel_rpc_timeout' => 0.0,
-            ],
-        ], $instance->constructParams);
-    }
+test('URL with percent-encoded values', function () {
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [
+        'url' => 'amqp://user%61:%61pass@ho%61st:10000/v%2fhost?keepalive=1&connection_timeout=6&read_write_timeout=6',
+    ]);
 
-    public function testClusterConnectionParametersWithoutRootConnectionKeys()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [
-                'hosts' => [
-                    [
-                        'host' => 'cluster_host',
-                        'port' => 123,
-                        'user' => 'cluster_user',
-                        'password' => 'cluster_password',
-                        'vhost' => '/cluster_vhost',
-                    ],
-                    [
-                        'url' => 'amqp://user:pass@host:321/vhost',
-                    ],
-                ],
-            ]
-        );
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            'cluster_host',     // host
-            123,                // port
-            'cluster_user',     // user
-            'cluster_password', // password
-            '/cluster_vhost',   // vhost
-            false,              // insist
-            "AMQPLAIN",         // login method
-            null,               // login response
-            "en_US",            // locale
-            3,                  // connection timeout
-            3,                  // read write timeout
-            null,               // context
-            false,              // keepalive
-            0,                  // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'hoast', 10000, 'usera', 'apass', 'v/host',
+        false, 'AMQPLAIN', null, 'en_US',
+        6, 6, null, true, 0, 0.0,
+    ]);
+});
 
-        $this->assertEquals(
-            [
-                [
-                    [
-                        'host' => 'cluster_host',
-                        'port' => 123,
-                        'user' => 'cluster_user',
-                        'password' => 'cluster_password',
-                        'vhost' => '/cluster_vhost',
-                    ],
-                    [
-                        'host' => 'host',
-                        'port' => 321,
-                        'user' => 'user',
-                        'password' => 'pass',
-                        'vhost' => 'vhost',
-                    ],
-                ],
-                [
-                    'url'                => '',
-                    'host'               => 'localhost',
-                    'port'               => 5672,
-                    'user'               => 'guest',
-                    'password'           => 'guest',
-                    'vhost'              => '/',
-                    'connection_timeout' => 3,
-                    'read_write_timeout' => 3,
-                    'ssl_context'        => null,
-                    'keepalive'          => false,
-                    'heartbeat'          => 0,
-                    'channel_rpc_timeout' => 0.0,
-                ],
-            ],
-            $instance::$createConnectionParams
-        );
-    }
+test('URL without vhost', function () {
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [
+        'url' => 'amqp://user:pass@host:321/?keepalive=1&connection_timeout=6&read_write_timeout=6',
+    ]);
 
-    public function testClusterConnectionParametersWithRootConnectionKeys()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [
-                'host' => 'host',
-                'port' => 123,
-                'user' => 'user',
-                'password' => 'password',
-                'vhost' => '/vhost',
-                'hosts' => [
-                    [
-                        'host' => 'cluster_host',
-                        'port' => 123,
-                        'user' => 'cluster_user',
-                        'password' => 'cluster_password',
-                        'vhost' => '/vhost',
-                    ],
-                ],
-            ]
-        );
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            'cluster_host',  // host
-            123,         // port
-            'cluster_user',  // user
-            'cluster_password', // password
-            '/vhost',    // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            3,           // connection timeout
-            3,           // read write timeout
-            null,        // context
-            false,       // keepalive
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'host', 321, 'user', 'pass', '',
+        false, 'AMQPLAIN', null, 'en_US',
+        6, 6, null, true, 0, 0.0,
+    ]);
+});
 
-        $this->assertEquals(
-            [
-                [
-                    [
-                        'host' => 'cluster_host',
-                        'port' => 123,
-                        'user' => 'cluster_user',
-                        'password' => 'cluster_password',
-                        'vhost' => '/vhost',
-                    ],
-                ],
-                [
-                    'url'                => '',
-                    'host'               => 'host',
-                    'port'               => 123,
-                    'user'               => 'user',
-                    'password'           => 'password',
-                    'vhost'              => '/vhost',
-                    'connection_timeout' => 3,
-                    'read_write_timeout' => 3,
-                    'ssl_context'        => null,
-                    'keepalive'          => false,
-                    'heartbeat'          => 0,
-                    'channel_rpc_timeout' => 0.0,
-                ],
-            ],
-            $instance::$createConnectionParams
-        );
-    }
+test('SSL connection parameters', function () {
+    $factory = new AMQPConnectionFactory(AMQPSSLConnection::class, [
+        'host'        => 'ssl_host',
+        'port'        => 123,
+        'user'        => 'ssl_user',
+        'password'    => 'ssl_password',
+        'vhost'       => '/ssl',
+        'ssl_context' => ['verify_peer' => false],
+    ]);
 
-    public function testSSLClusterConnectionParameters()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPSSLConnection::class,
-            [
-                'hosts' => [
-                    [
-                        'host' => 'ssl_cluster_host',
-                        'port' => 123,
-                        'user' => 'ssl_cluster_user',
-                        'password' => 'ssl_cluster_password',
-                        'vhost' => '/ssl_cluster_vhost',
-                    ],
-                    [
-                        'url' => 'amqp://user:pass@host:321/vhost',
-                    ],
-                ],
-                'ssl_context' => [
-                    'verify_peer' => false,
-                ],
-            ]
-        );
+    /** @var AMQPSSLConnection $instance */
+    $instance = $factory->createConnection();
 
-        /** @var AMQPSSLConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPSSLConnection::class, $instance);
+    expect($instance)->toBeInstanceOf(AMQPSSLConnection::class);
+    expect($instance->constructParams)->toHaveKey(6);
 
-        $this->assertArrayHasKey(6, $instance->constructParams);
-        $options = $instance->constructParams[6];
-        $this->assertArrayHasKey('ssl_context', $options);
-        $this->assertArrayHasKey('context', $options);
-        $context = $options['context'];
-        // unset to check whole array at once later
-        $instance->constructParams[6]['ssl_context'] = null;
-        $instance->constructParams[6]['context'] = null;
-        $this->assertIsResource($context);
-        $this->assertEquals('stream-context', get_resource_type($context));
-        $options = stream_context_get_options($context);
-        $this->assertEquals(['ssl' => ['verify_peer' => false]], $options);
+    $options = $instance->constructParams[6];
+    expect($options)->toHaveKey('ssl_context');
+    expect($options)->toHaveKey('context');
 
-        $this->assertArrayHasKey(1, $instance::$createConnectionParams);
-        $createConnectionOptions = $instance::$createConnectionParams[1];
-        $this->assertArrayHasKey('ssl_context', $createConnectionOptions);
-        $createConnectionContext = $createConnectionOptions['context'];
-        // unset to check whole array at once later
-        $instance::$createConnectionParams[1]['ssl_context'] = null;
-        $instance::$createConnectionParams[1]['context'] = null;
-        $this->assertIsResource($createConnectionContext);
-        $this->assertEquals('stream-context', get_resource_type($createConnectionContext));
-        $createConnectionOptions = stream_context_get_options($createConnectionContext);
-        $this->assertEquals(['ssl' => ['verify_peer' => false]], $createConnectionOptions);
+    $context = $options['context'];
+    $instance->constructParams[6]['ssl_context'] = null;
+    $instance->constructParams[6]['context'] = null;
 
-        $this->assertEquals([
-            'ssl_cluster_host',     // host
-            123,                   // port
-            'ssl_cluster_user',     // user
-            'ssl_cluster_password', // password
-            '/ssl_cluster_vhost',   // vhost,
-            [],                     // ssl_options
-            [                       // options
-                'url' => '',
-                'host' => 'localhost',
-                'port' => 5672,
-                'user' => 'guest',
-                'password' => 'guest',
-                'vhost' => '/',
-                'connection_timeout' => 3,
-                'read_write_timeout' => 3,
-                'ssl_context' => null,
-                'context' => null,
-                'keepalive' => false,
-                'heartbeat' => 0,
-                'channel_rpc_timeout' => 0.0,
-            ],
-        ], $instance->constructParams);
+    $this->assertIsResource($context);
+    expect(get_resource_type($context))->toBe('stream-context');
+    expect(stream_context_get_options($context))->toEqual(['ssl' => ['verify_peer' => false]]);
 
-        $this->assertEquals(
-            [
-                [
-                    [
-                        'host' => 'ssl_cluster_host',
-                        'port' => 123,
-                        'user' => 'ssl_cluster_user',
-                        'password' => 'ssl_cluster_password',
-                        'vhost' => '/ssl_cluster_vhost',
-                    ],
-                    [
-                        'host' => 'host',
-                        'port' => 321,
-                        'user' => 'user',
-                        'password' => 'pass',
-                        'vhost' => 'vhost',
-                    ],
-                ],
-                [
-                    'url'                => '',
-                    'host'               => 'localhost',
-                    'port'               => 5672,
-                    'user'               => 'guest',
-                    'password'           => 'guest',
-                    'vhost'              => '/',
-                    'connection_timeout' => 3,
-                    'read_write_timeout' => 3,
-                    'ssl_context'        => null, // context checked earlier
-                    'context'        => null, // context checked earlier
-                    'keepalive'          => false,
-                    'heartbeat'          => 0,
-                    'channel_rpc_timeout' => 0.0,
-                ],
-            ],
-            $instance::$createConnectionParams
-        );
-    }
+    expect($instance->constructParams)->toEqual([
+        'ssl_host', 123, 'ssl_user', 'ssl_password', '/ssl',
+        [],
+        [
+            'url'                 => '',
+            'host'                => 'ssl_host',
+            'port'                => 123,
+            'user'                => 'ssl_user',
+            'password'            => 'ssl_password',
+            'vhost'               => '/ssl',
+            'connection_timeout'  => 3,
+            'read_write_timeout'  => 3,
+            'ssl_context'         => null,
+            'context'             => null,
+            'keepalive'           => false,
+            'heartbeat'           => 0,
+            'channel_rpc_timeout' => 0.0,
+        ],
+    ]);
+});
 
-    public function testSocketClusterConnectionParameters()
-    {
-        $factory = new AMQPConnectionFactory(
-            AMQPSocketConnection::class,
-            [
-                'hosts' => [
-                    [
-                        'host' => 'cluster_host',
-                        'port' => 123,
-                        'user' => 'cluster_user',
-                        'password' => 'cluster_password',
-                        'vhost' => '/cluster_vhost',
-                    ],
-                    [
-                        'url' => 'amqp://user:pass@host:321/vhost',
-                    ],
-                ],
-            ]
-        );
+test('cluster connection without root connection keys', function () {
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [
+        'hosts' => [
+            ['host' => 'cluster_host', 'port' => 123, 'user' => 'cluster_user', 'password' => 'cluster_password', 'vhost' => '/cluster_vhost'],
+            ['url' => 'amqp://user:pass@host:321/vhost'],
+        ],
+    ]);
 
-        /** @var AMQPSocketConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPSocketConnection::class, $instance);
-        $this->assertEquals([
-            'cluster_host',     // host
-            123,                // port
-            'cluster_user',     // user
-            'cluster_password', // password
-            '/cluster_vhost',   // vhost
-            false,              // insist
-            "AMQPLAIN",         // login method
-            null,               // login response
-            "en_US",            // locale
-            3,                  // read_timeout
-            false,              // keepalive
-            3,                  // write_timeout
-            0,                  // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
 
-        $this->assertEquals(
-            [
-                [
-                    [
-                        'host' => 'cluster_host',
-                        'port' => 123,
-                        'user' => 'cluster_user',
-                        'password' => 'cluster_password',
-                        'vhost' => '/cluster_vhost',
-                    ],
-                    [
-                        'host' => 'host',
-                        'port' => 321,
-                        'user' => 'user',
-                        'password' => 'pass',
-                        'vhost' => 'vhost',
-                    ],
-                ],
-                [
-                    'url'                => '',
-                    'host'               => 'localhost',
-                    'port'               => 5672,
-                    'user'               => 'guest',
-                    'password'           => 'guest',
-                    'vhost'              => '/',
-                    'ssl_context'        => null,
-                    'keepalive'          => false,
-                    'heartbeat'          => 0,
-                    'connection_timeout' => 3,
-                    'read_write_timeout' => 3,
-                    'read_timeout'       => 3,
-                    'write_timeout'      => 3,
-                    'channel_rpc_timeout' => 0.0,
-                ],
-            ],
-            $instance::$createConnectionParams
-        );
-    }
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'cluster_host', 123, 'cluster_user', 'cluster_password', '/cluster_vhost',
+        false, 'AMQPLAIN', null, 'en_US',
+        3, 3, null, false, 0, 0.0,
+    ]);
 
-    public function testConnectionsParametersProviderWithConstructorArgs()
-    {
-        $connectionParametersProvider = $this->prepareConnectionParametersProvider();
-        $connectionParametersProvider->expects($this->once())
-            ->method('getConnectionParameters')
-            ->will($this->returnValue(
-                [
-                    'constructor_args' => [1,2,3,4],
-                ]
-            ));
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [],
-            $connectionParametersProvider
-        );
+    expect($instance::$createConnectionParams)->toEqual([
+        [
+            ['host' => 'cluster_host', 'port' => 123, 'user' => 'cluster_user', 'password' => 'cluster_password', 'vhost' => '/cluster_vhost'],
+            ['host' => 'host', 'port' => 321, 'user' => 'user', 'password' => 'pass', 'vhost' => 'vhost'],
+        ],
+        [
+            'url' => '', 'host' => 'localhost', 'port' => 5672, 'user' => 'guest', 'password' => 'guest',
+            'vhost' => '/', 'connection_timeout' => 3, 'read_write_timeout' => 3,
+            'ssl_context' => null, 'keepalive' => false, 'heartbeat' => 0, 'channel_rpc_timeout' => 0.0,
+        ],
+    ]);
+});
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([1,2,3,4], $instance->constructParams);
-    }
+test('cluster connection with root connection keys', function () {
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [
+        'host'     => 'host',
+        'port'     => 123,
+        'user'     => 'user',
+        'password' => 'password',
+        'vhost'    => '/vhost',
+        'hosts'    => [
+            ['host' => 'cluster_host', 'port' => 123, 'user' => 'cluster_user', 'password' => 'cluster_password', 'vhost' => '/vhost'],
+        ],
+    ]);
 
-    public function testConnectionsParametersProvider()
-    {
-        $connectionParametersProvider = $this->prepareConnectionParametersProvider();
-        $connectionParametersProvider->expects($this->once())
-            ->method('getConnectionParameters')
-            ->will($this->returnValue(
-                [
-                    'host' => '1.2.3.4',
-                    'port' => 5678,
-                    'user' => 'admin',
-                    'password' => 'admin',
-                    'vhost' => 'foo',
-                ]
-            ));
-        $factory = new AMQPConnectionFactory(
-            AMQPConnection::class,
-            [],
-            $connectionParametersProvider
-        );
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
 
-        /** @var AMQPConnection $instance */
-        $instance = $factory->createConnection();
-        $this->assertInstanceOf(AMQPConnection::class, $instance);
-        $this->assertEquals([
-            '1.2.3.4',   // host
-            5678,        // port
-            'admin',     // user
-            'admin',     // password
-            'foo',       // vhost
-            false,       // insist
-            "AMQPLAIN",  // login method
-            null,        // login response
-            "en_US",     // locale
-            3,           // connection timeout
-            3,           // read write timeout
-            null,        // context
-            false,       // keepalive
-            0,           // heartbeat
-            0.0,         //channel_rpc_timeout
-        ], $instance->constructParams);
-    }
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'cluster_host', 123, 'cluster_user', 'cluster_password', '/vhost',
+        false, 'AMQPLAIN', null, 'en_US',
+        3, 3, null, false, 0, 0.0,
+    ]);
 
-    /**
-     * Preparing ConnectionParametersProviderInterface instance
-     *
-     * @return ConnectionParametersProviderInterface|MockObject
-     */
-    private function prepareConnectionParametersProvider()
-    {
-        return $this->getMockBuilder(ConnectionParametersProviderInterface::class)
-            ->getMock();
-    }
-}
+    expect($instance::$createConnectionParams)->toEqual([
+        [
+            ['host' => 'cluster_host', 'port' => 123, 'user' => 'cluster_user', 'password' => 'cluster_password', 'vhost' => '/vhost'],
+        ],
+        [
+            'url' => '', 'host' => 'host', 'port' => 123, 'user' => 'user', 'password' => 'password',
+            'vhost' => '/vhost', 'connection_timeout' => 3, 'read_write_timeout' => 3,
+            'ssl_context' => null, 'keepalive' => false, 'heartbeat' => 0, 'channel_rpc_timeout' => 0.0,
+        ],
+    ]);
+});
+
+test('SSL cluster connection parameters', function () {
+    $factory = new AMQPConnectionFactory(AMQPSSLConnection::class, [
+        'hosts' => [
+            ['host' => 'ssl_cluster_host', 'port' => 123, 'user' => 'ssl_cluster_user', 'password' => 'ssl_cluster_password', 'vhost' => '/ssl_cluster_vhost'],
+            ['url' => 'amqp://user:pass@host:321/vhost'],
+        ],
+        'ssl_context' => ['verify_peer' => false],
+    ]);
+
+    /** @var AMQPSSLConnection $instance */
+    $instance = $factory->createConnection();
+
+    expect($instance)->toBeInstanceOf(AMQPSSLConnection::class);
+
+    expect($instance->constructParams)->toHaveKey(6);
+    $options = $instance->constructParams[6];
+    expect($options)->toHaveKey('ssl_context');
+    expect($options)->toHaveKey('context');
+    $context = $options['context'];
+    $instance->constructParams[6]['ssl_context'] = null;
+    $instance->constructParams[6]['context'] = null;
+
+    $this->assertIsResource($context);
+    expect(get_resource_type($context))->toBe('stream-context');
+    expect(stream_context_get_options($context))->toEqual(['ssl' => ['verify_peer' => false]]);
+
+    expect($instance::$createConnectionParams)->toHaveKey(1);
+    $createConnectionOptions = $instance::$createConnectionParams[1];
+    expect($createConnectionOptions)->toHaveKey('ssl_context');
+    $createConnectionContext = $createConnectionOptions['context'];
+    $instance::$createConnectionParams[1]['ssl_context'] = null;
+    $instance::$createConnectionParams[1]['context'] = null;
+    $this->assertIsResource($createConnectionContext);
+    expect(get_resource_type($createConnectionContext))->toBe('stream-context');
+    expect(stream_context_get_options($createConnectionContext))->toEqual(['ssl' => ['verify_peer' => false]]);
+
+    expect($instance->constructParams)->toEqual([
+        'ssl_cluster_host', 123, 'ssl_cluster_user', 'ssl_cluster_password', '/ssl_cluster_vhost',
+        [],
+        [
+            'url' => '', 'host' => 'localhost', 'port' => 5672, 'user' => 'guest', 'password' => 'guest',
+            'vhost' => '/', 'connection_timeout' => 3, 'read_write_timeout' => 3,
+            'ssl_context' => null, 'context' => null,
+            'keepalive' => false, 'heartbeat' => 0, 'channel_rpc_timeout' => 0.0,
+        ],
+    ]);
+
+    expect($instance::$createConnectionParams)->toEqual([
+        [
+            ['host' => 'ssl_cluster_host', 'port' => 123, 'user' => 'ssl_cluster_user', 'password' => 'ssl_cluster_password', 'vhost' => '/ssl_cluster_vhost'],
+            ['host' => 'host', 'port' => 321, 'user' => 'user', 'password' => 'pass', 'vhost' => 'vhost'],
+        ],
+        [
+            'url' => '', 'host' => 'localhost', 'port' => 5672, 'user' => 'guest', 'password' => 'guest',
+            'vhost' => '/', 'connection_timeout' => 3, 'read_write_timeout' => 3,
+            'ssl_context' => null, 'context' => null,
+            'keepalive' => false, 'heartbeat' => 0, 'channel_rpc_timeout' => 0.0,
+        ],
+    ]);
+});
+
+test('socket cluster connection parameters', function () {
+    $factory = new AMQPConnectionFactory(AMQPSocketConnection::class, [
+        'hosts' => [
+            ['host' => 'cluster_host', 'port' => 123, 'user' => 'cluster_user', 'password' => 'cluster_password', 'vhost' => '/cluster_vhost'],
+            ['url' => 'amqp://user:pass@host:321/vhost'],
+        ],
+    ]);
+
+    /** @var AMQPSocketConnection $instance */
+    $instance = $factory->createConnection();
+
+    expect($instance)->toBeInstanceOf(AMQPSocketConnection::class);
+    expect($instance->constructParams)->toEqual([
+        'cluster_host', 123, 'cluster_user', 'cluster_password', '/cluster_vhost',
+        false, 'AMQPLAIN', null, 'en_US',
+        3, false, 3, 0, 0.0,
+    ]);
+
+    expect($instance::$createConnectionParams)->toEqual([
+        [
+            ['host' => 'cluster_host', 'port' => 123, 'user' => 'cluster_user', 'password' => 'cluster_password', 'vhost' => '/cluster_vhost'],
+            ['host' => 'host', 'port' => 321, 'user' => 'user', 'password' => 'pass', 'vhost' => 'vhost'],
+        ],
+        [
+            'url' => '', 'host' => 'localhost', 'port' => 5672, 'user' => 'guest', 'password' => 'guest',
+            'vhost' => '/', 'connection_timeout' => 3, 'read_write_timeout' => 3,
+            'ssl_context' => null, 'keepalive' => false, 'heartbeat' => 0,
+            'read_timeout' => 3, 'write_timeout' => 3, 'channel_rpc_timeout' => 0.0,
+        ],
+    ]);
+});
+
+test('connection parameters provider with constructor args', function () {
+    $provider = $this->getMockBuilder(ConnectionParametersProviderInterface::class)->getMock();
+    $provider->expects($this->once())
+        ->method('getConnectionParameters')
+        ->willReturn(['constructor_args' => [1, 2, 3, 4]]);
+
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [], $provider);
+
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
+
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([1, 2, 3, 4]);
+});
+
+test('connection parameters provider with standard parameters', function () {
+    $provider = $this->getMockBuilder(ConnectionParametersProviderInterface::class)->getMock();
+    $provider->expects($this->once())
+        ->method('getConnectionParameters')
+        ->willReturn([
+            'host'     => '1.2.3.4',
+            'port'     => 5678,
+            'user'     => 'admin',
+            'password' => 'admin',
+            'vhost'    => 'foo',
+        ]);
+
+    $factory = new AMQPConnectionFactory(AMQPConnection::class, [], $provider);
+
+    /** @var AMQPConnection $instance */
+    $instance = $factory->createConnection();
+
+    expect($instance)->toBeInstanceOf(AMQPConnection::class);
+    expect($instance->constructParams)->toEqual([
+        '1.2.3.4', 5678, 'admin', 'admin', 'foo',
+        false, 'AMQPLAIN', null, 'en_US',
+        3, 3, null, false, 0, 0.0,
+    ]);
+});

--- a/Tests/RabbitMq/BaseAmqpTest.php
+++ b/Tests/RabbitMq/BaseAmqpTest.php
@@ -1,84 +1,48 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
-use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 use OldSound\RabbitMqBundle\Event\AMQPEvent;
-use OldSound\RabbitMqBundle\RabbitMq\BaseAmqp;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
-use PHPUnit\Framework\TestCase;
 
-class BaseAmqpTest extends TestCase
-{
-    public function testLazyConnection()
-    {
-        $connection = $this->getMockBuilder('PhpAmqpLib\Connection\AbstractConnection')
-            ->disableOriginalConstructor()
-            ->getMock();
+test('lazy connection does not open channel on construction', function () {
+    $connection = $this->getMockBuilder('PhpAmqpLib\Connection\AbstractConnection')
+        ->disableOriginalConstructor()
+        ->getMock();
 
-        $connection
-            ->method('connectOnConstruct')
-            ->willReturn(false);
-        $connection
-            ->expects(static::never())
-            ->method('channel');
+    $connection->method('connectOnConstruct')->willReturn(false);
+    $connection->expects(static::never())->method('channel');
 
-        new Consumer($connection, null);
-    }
+    new Consumer($connection, null);
+});
 
-    public function testNotLazyConnection()
-    {
-        $connection = $this->getMockBuilder('PhpAmqpLib\Connection\AbstractConnection')
-            ->disableOriginalConstructor()
-            ->getMock();
+test('non-lazy connection opens channel on construction', function () {
+    $connection = $this->getMockBuilder('PhpAmqpLib\Connection\AbstractConnection')
+        ->disableOriginalConstructor()
+        ->getMock();
 
-        $connection
-            ->method('connectOnConstruct')
-            ->willReturn(true);
-        $connection
-            ->expects(static::once())
-            ->method('channel');
+    $connection->method('connectOnConstruct')->willReturn(true);
+    $connection->expects(static::once())->method('channel');
 
-        new Consumer($connection, null);
-    }
+    new Consumer($connection, null);
+});
 
-    public function testDispatchEvent()
-    {
-        /** @var BaseAmqp|MockObject $baseAmqpConsumer */
-        $baseAmqpConsumer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\BaseAmqp')
-            ->disableOriginalConstructor()
-            ->getMock();
+test('dispatch event delegates to event dispatcher', function () {
+    $baseAmqpConsumer = $this->getMockBuilder('OldSound\RabbitMqBundle\RabbitMq\BaseAmqp')
+        ->disableOriginalConstructor()
+        ->getMock();
 
-        $eventDispatcher = $this->getMockBuilder('Symfony\Contracts\EventDispatcher\EventDispatcherInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
+    $eventDispatcher = $this->getMockBuilder('Symfony\Contracts\EventDispatcher\EventDispatcherInterface')
+        ->disableOriginalConstructor()
+        ->getMock();
 
-        $baseAmqpConsumer->expects($this->atLeastOnce())
-            ->method('getEventDispatcher')
-            ->willReturn($eventDispatcher);
+    $baseAmqpConsumer->method('getEventDispatcher')->willReturn($eventDispatcher);
 
-        $eventDispatcher->expects($this->once())
-            ->method('dispatch')
-            ->with(new AMQPEvent(), AMQPEvent::ON_CONSUME)
-            ->willReturn(new AMQPEvent());
+    $eventDispatcher->expects($this->once())
+        ->method('dispatch')
+        ->with(new AMQPEvent(), AMQPEvent::ON_CONSUME)
+        ->willReturn(new AMQPEvent());
 
-        $this->invokeMethod('dispatchEvent', $baseAmqpConsumer, [AMQPEvent::ON_CONSUME, new AMQPEvent()]);
-    }
-
-    /**
-     * @param string $name
-     * @param MockObject $obj
-     * @param array $params
-     *
-     * @return mixed
-     */
-    protected function invokeMethod($name, $obj, $params)
-    {
-        $class = new \ReflectionClass(get_class($obj));
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-
-        return $method->invokeArgs($obj, $params);
-    }
-}
+    $class = new \ReflectionClass(get_class($baseAmqpConsumer));
+    $method = $class->getMethod('dispatchEvent');
+    $method->setAccessible(true);
+    $method->invokeArgs($baseAmqpConsumer, [AMQPEvent::ON_CONSUME, new AMQPEvent()]);
+});

--- a/Tests/RabbitMq/BaseConsumerTest.php
+++ b/Tests/RabbitMq/BaseConsumerTest.php
@@ -7,7 +7,7 @@ beforeEach(function () {
         ->disableOriginalConstructor()
         ->getMock();
 
-    $this->consumer = new class($amqpConnection) extends BaseConsumer {};
+    $this->consumer = new class ($amqpConnection) extends BaseConsumer {};
 });
 
 test('it extends BaseAmqp', function () {

--- a/Tests/RabbitMq/BaseConsumerTest.php
+++ b/Tests/RabbitMq/BaseConsumerTest.php
@@ -1,47 +1,35 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
 use OldSound\RabbitMqBundle\RabbitMq\BaseConsumer;
-use PHPUnit\Framework\TestCase;
 
-class BaseConsumerTest extends TestCase
-{
-    /** @var BaseConsumer */
-    protected $consumer;
+beforeEach(function () {
+    $amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+        ->disableOriginalConstructor()
+        ->getMock();
 
-    protected function setUp(): void
-    {
-        $amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
-            ->disableOriginalConstructor()
-            ->getMock();
+    $this->consumer = new class($amqpConnection) extends BaseConsumer {};
+});
 
-        $this->consumer = $this->getMockBuilder('\OldSound\RabbitMqBundle\RabbitMq\BaseConsumer')
-            ->setConstructorArgs([$amqpConnection])
-            ->getMockForAbstractClass();
-    }
+test('it extends BaseAmqp', function () {
+    expect($this->consumer)->toBeInstanceOf('OldSound\RabbitMqBundle\RabbitMq\BaseAmqp');
+});
 
-    public function testItExtendsBaseAmqpInterface()
-    {
-        $this->assertInstanceOf('OldSound\RabbitMqBundle\RabbitMq\BaseAmqp', $this->consumer);
-    }
+test('it implements DequeuerInterface', function () {
+    expect($this->consumer)->toBeInstanceOf('OldSound\RabbitMqBundle\RabbitMq\DequeuerInterface');
+});
 
-    public function testItImplementsDequeuerInterface()
-    {
-        $this->assertInstanceOf('OldSound\RabbitMqBundle\RabbitMq\DequeuerInterface', $this->consumer);
-    }
+test('idle timeout is mutable', function () {
+    expect($this->consumer->getIdleTimeout())->toBe(0);
 
-    public function testItsIdleTimeoutIsMutable()
-    {
-        $this->assertEquals(0, $this->consumer->getIdleTimeout());
-        $this->consumer->setIdleTimeout(42);
-        $this->assertEquals(42, $this->consumer->getIdleTimeout());
-    }
+    $this->consumer->setIdleTimeout(42);
 
-    public function testItsIdleTimeoutExitCodeIsMutable()
-    {
-        $this->assertEquals(0, $this->consumer->getIdleTimeoutExitCode());
-        $this->consumer->setIdleTimeoutExitCode(43);
-        $this->assertEquals(43, $this->consumer->getIdleTimeoutExitCode());
-    }
-}
+    expect($this->consumer->getIdleTimeout())->toBe(42);
+});
+
+test('idle timeout exit code is mutable', function () {
+    expect($this->consumer->getIdleTimeoutExitCode())->toBeNull();
+
+    $this->consumer->setIdleTimeoutExitCode(43);
+
+    expect($this->consumer->getIdleTimeoutExitCode())->toBe(43);
+});

--- a/Tests/RabbitMq/BindingTest.php
+++ b/Tests/RabbitMq/BindingTest.php
@@ -1,89 +1,54 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
 use OldSound\RabbitMqBundle\RabbitMq\Binding;
-use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
-class BindingTest extends TestCase
-{
-    protected function getBinding($amqpConnection, $amqpChannel)
-    {
-        return new Binding($amqpConnection, $amqpChannel);
-    }
+test('queue bind delegates to channel with correct arguments', function () {
+    $connection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+        ->disableOriginalConstructor()
+        ->getMock();
 
-    /**
-     * @return MockObject
-     */
-    protected function prepareAMQPConnection()
-    {
-        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
+    $channel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+        ->disableOriginalConstructor()
+        ->getMock();
+    $channel->method('getChannelId')->willReturn('channel_id');
 
-    protected function prepareAMQPChannel($channelId = null)
-    {
-        $channelMock = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
+    $source      = 'example_source';
+    $destination = 'example_destination';
+    $key         = 'example_key';
 
-        $channelMock->expects($this->any())
-            ->method('getChannelId')
-            ->willReturn($channelId);
-        return $channelMock;
-    }
+    $channel->expects($this->once())
+        ->method('queue_bind')
+        ->with($destination, $source, $key, false, null);
 
-    public function testQueueBind()
-    {
-        $ch = $this->prepareAMQPChannel('channel_id');
-        $con = $this->prepareAMQPConnection();
+    $binding = new Binding($connection, $channel);
+    $binding->setExchange($source);
+    $binding->setDestination($destination);
+    $binding->setRoutingKey($key);
+    $binding->setupFabric();
+});
 
-        $source = 'example_source';
-        $destination = 'example_destination';
-        $key = 'example_key';
-        $ch->expects($this->once())
-            ->method('queue_bind')
-            ->will($this->returnCallback(function ($d, $s, $k, $n, $a) use ($destination, $source, $key) {
-                Assert::assertSame($destination, $d);
-                Assert::assertSame($source, $s);
-                Assert::assertSame($key, $k);
-                Assert::assertFalse($n);
-                Assert::assertNull($a);
-            }));
+test('exchange bind delegates to channel with correct arguments', function () {
+    $connection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+        ->disableOriginalConstructor()
+        ->getMock();
 
-        $binding = $this->getBinding($con, $ch);
-        $binding->setExchange($source);
-        $binding->setDestination($destination);
-        $binding->setRoutingKey($key);
-        $binding->setupFabric();
-    }
+    $channel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+        ->disableOriginalConstructor()
+        ->getMock();
+    $channel->method('getChannelId')->willReturn('channel_id');
 
-    public function testExhangeBind()
-    {
-        $ch = $this->prepareAMQPChannel('channel_id');
-        $con = $this->prepareAMQPConnection();
+    $source      = 'example_source';
+    $destination = 'example_destination';
+    $key         = 'example_key';
 
-        $source = 'example_source';
-        $destination = 'example_destination';
-        $key = 'example_key';
-        $ch->expects($this->once())
-            ->method('exchange_bind')
-            ->will($this->returnCallback(function ($d, $s, $k, $n, $a) use ($destination, $source, $key) {
-                Assert::assertSame($destination, $d);
-                Assert::assertSame($source, $s);
-                Assert::assertSame($key, $k);
-                Assert::assertFalse($n);
-                Assert::assertNull($a);
-            }));
+    $channel->expects($this->once())
+        ->method('exchange_bind')
+        ->with($destination, $source, $key, false, null);
 
-        $binding = $this->getBinding($con, $ch);
-        $binding->setExchange($source);
-        $binding->setDestination($destination);
-        $binding->setRoutingKey($key);
-        $binding->setDestinationIsExchange(true);
-        $binding->setupFabric();
-    }
-}
+    $binding = new Binding($connection, $channel);
+    $binding->setExchange($source);
+    $binding->setDestination($destination);
+    $binding->setRoutingKey($key);
+    $binding->setDestinationIsExchange(true);
+    $binding->setupFabric();
+});

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -24,7 +24,7 @@ test('process message with various flags', function (string $consumerClass, mixe
     $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
     $consumer       = new $consumerClass($amqpConnection, $amqpChannel);
 
-    $consumer->setCallback(static fn() => $processFlag);
+    $consumer->setCallback(static fn () => $processFlag);
 
     $amqpMessage = new AMQPMessage('foo body');
     $amqpMessage->setChannel($amqpChannel);
@@ -175,7 +175,7 @@ test('consumption continues after idle timeout when force stop is false', functi
 
     $consumer->setEventDispatcher($eventDispatcher);
 
-    expect(fn() => $consumer->consume(10))->toThrow(AMQPTimeoutException::class);
+    expect(fn () => $consumer->consume(10))->toThrow(AMQPTimeoutException::class);
 })->with('consumer_classes');
 
 test('graceful max execution will not wait if past timeout', function (string $consumerClass) {

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -1,504 +1,252 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
 use OldSound\RabbitMqBundle\Event\AfterProcessingMessageEvent;
 use OldSound\RabbitMqBundle\Event\BeforeProcessingMessageEvent;
 use OldSound\RabbitMqBundle\Event\OnConsumeEvent;
 use OldSound\RabbitMqBundle\Event\OnIdleEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
+use OldSound\RabbitMqBundle\RabbitMq\DynamicConsumer;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
-use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
-use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
-class ConsumerTest extends TestCase
-{
-    protected function getConsumer($amqpConnection, $amqpChannel)
-    {
-        return new Consumer($amqpConnection, $amqpChannel);
+// Dataset: run all consumer behaviour tests for both Consumer and DynamicConsumer
+dataset('consumer_classes', [
+    'Consumer'        => [Consumer::class],
+    'DynamicConsumer' => [DynamicConsumer::class],
+]);
+
+test('process message with various flags', function (string $consumerClass, mixed $processFlag, ?string $expectedMethod, ?bool $expectedRequeue) {
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
+    $consumer       = new $consumerClass($amqpConnection, $amqpChannel);
+
+    $consumer->setCallback(static fn() => $processFlag);
+
+    $amqpMessage = new AMQPMessage('foo body');
+    $amqpMessage->setChannel($amqpChannel);
+    $amqpMessage->setDeliveryTag(0);
+
+    if ($expectedMethod) {
+        $amqpChannel->method('basic_reject')
+            ->willReturnCallback(function ($tag, $requeue) use ($expectedMethod, $expectedRequeue) {
+                expect($expectedMethod)->toBe('basic_reject');
+                expect($requeue)->toBe($expectedRequeue);
+            });
+
+        $amqpChannel->method('basic_ack')
+            ->willReturnCallback(function () use ($expectedMethod) {
+                expect($expectedMethod)->toBe('basic_ack');
+            });
+    } else {
+        $amqpChannel->expects($this->never())->method('basic_reject');
+        $amqpChannel->expects($this->never())->method('basic_ack');
+        $amqpChannel->expects($this->never())->method('basic_nack');
     }
 
-    protected function prepareAMQPConnection()
-    {
-        return $this->getMockBuilder(AMQPStreamConnection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
+    $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->disableOriginalConstructor()->getMock();
+    $consumer->setEventDispatcher($eventDispatcher);
 
-    protected function prepareAMQPChannel()
-    {
-        return $this->getMockBuilder(AMQPChannel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
+    $callIndex = 0;
+    $eventDispatcher->method('dispatch')
+        ->willReturnCallback(function ($event) use (&$callIndex, $consumer, $amqpMessage) {
+            if ($callIndex === 0) {
+                expect($event)->toEqual(new BeforeProcessingMessageEvent($consumer, $amqpMessage));
+            } else {
+                expect($event)->toEqual(new AfterProcessingMessageEvent($consumer, $amqpMessage));
+            }
+            $callIndex++;
 
-    /**
-     * Check if the message is requeued or not correctly.
-     *
-     * @dataProvider processMessageProvider
-     */
-    public function testProcessMessage($processFlag, $expectedMethod = null, $expectedRequeue = null)
-    {
-        $amqpConnection = $this->prepareAMQPConnection();
-        $amqpChannel = $this->prepareAMQPChannel();
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
+            return $event;
+        });
 
-        $callbackFunction = function () use ($processFlag) {
-            return $processFlag;
-        }; // Create a callback function with a return value set by the data provider.
-        $consumer->setCallback($callbackFunction);
+    $consumer->processMessage($amqpMessage);
+})->with('consumer_classes')->with([
+    'ack on null return'              => [null,                              'basic_ack',    null],
+    'ack on true return'              => [true,                              'basic_ack',    null],
+    'reject and requeue on false'     => [false,                             'basic_reject', true],
+    'ack on MSG_ACK'                  => [ConsumerInterface::MSG_ACK,        'basic_ack',    null],
+    'reject and requeue on MSG_REJECT_REQUEUE' => [ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true],
+    'reject and drop on MSG_REJECT'   => [ConsumerInterface::MSG_REJECT,     'basic_reject', false],
+    'no ack on MSG_ACK_SENT'          => [ConsumerInterface::MSG_ACK_SENT,   null,           null],
+]);
 
-        // Create a default message
-        $amqpMessage = new AMQPMessage('foo body');
-        $amqpMessage->setChannel($amqpChannel);
-        $amqpMessage->setDeliveryTag(0);
+test('consume dispatches consume event and stops when not consuming', function (string $consumerClass, array $data) {
+    $messageCount   = count($data['messages']);
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
 
-        if ($expectedMethod) {
-            $amqpChannel->expects($this->any())
-                ->method('basic_reject')
-                ->will($this->returnCallback(function ($delivery_tag, $requeue) use ($expectedMethod, $expectedRequeue) {
-                    Assert::assertSame($expectedMethod, 'basic_reject'); // Check if this function should be called.
-                    Assert::assertSame($requeue, $expectedRequeue); // Check if the message should be requeued.
-                }));
+    $amqpChannel->method('getChannelId')->willReturn(true);
+    $amqpChannel->expects($this->once())->method('basic_consume')->withAnyParameters()->willReturn(true);
+    // The loop runs exactly once: 1st is_consuming → true (enter loop), wait() runs,
+    // 2nd is_consuming → false (exit loop). messageCount only affects willReturn values.
+    $amqpChannel->expects(self::exactly(2))
+        ->method('is_consuming')
+        ->willReturnOnConsecutiveCalls(true, false);
 
-            $amqpChannel->expects($this->any())
-                ->method('basic_ack')
-                ->will($this->returnCallback(function ($delivery_tag) use ($expectedMethod) {
-                    Assert::assertSame($expectedMethod, 'basic_ack'); // Check if this function should be called.
-                }));
-        } else {
-            $amqpChannel->expects($this->never())->method('basic_reject');
-            $amqpChannel->expects($this->never())->method('basic_ack');
-            $amqpChannel->expects($this->never())->method('basic_nack');
-        }
+    $consumer = new $consumerClass($amqpConnection, $amqpChannel);
+    $consumer->disableAutoSetupFabric();
+    $consumer->setChannel($amqpChannel);
 
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+    $amqpChannel->expects(self::exactly(1))
+        ->method('wait')
+        ->with(null, false, $consumer->getIdleTimeout())
+        ->willReturn(true);
 
-        $consumer->setEventDispatcher($eventDispatcher);
+    $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->disableOriginalConstructor()->getMock();
+    $eventDispatcher->expects(self::exactly(1))
+        ->method('dispatch')
+        ->with($this->isInstanceOf(OnConsumeEvent::class), OnConsumeEvent::NAME)
+        ->willReturn($this->isInstanceOf(OnConsumeEvent::class));
 
-        $eventDispatcher->expects($this->atLeastOnce())
-            ->method('dispatch')
-            ->withConsecutive(
-                [new BeforeProcessingMessageEvent($consumer, $amqpMessage), BeforeProcessingMessageEvent::NAME],
-                [new AfterProcessingMessageEvent($consumer, $amqpMessage), AfterProcessingMessageEvent::NAME]
-            )
-            ->willReturnOnConsecutiveCalls(
-                new BeforeProcessingMessageEvent($consumer, $amqpMessage),
-                new AfterProcessingMessageEvent($consumer, $amqpMessage)
+    $consumer->setEventDispatcher($eventDispatcher);
+    $consumer->consume(1);
+})->with('consumer_classes')->with([
+    'with 4 messages' => [['messages' => ['msg1', 'msg2', 'msg3', 'msg4']]],
+    'with no messages' => [['messages' => []]],
+]);
+
+test('idle timeout returns configured exit code', function (string $consumerClass) {
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
+
+    $amqpChannel->method('getChannelId')->willReturn(true);
+    $amqpChannel->expects($this->once())->method('basic_consume')->withAnyParameters()->willReturn(true);
+    $amqpChannel->method('is_consuming')->willReturn(true);
+
+    $consumer = new $consumerClass($amqpConnection, $amqpChannel);
+    $consumer->disableAutoSetupFabric();
+    $consumer->setChannel($amqpChannel);
+    $consumer->setIdleTimeout(60);
+    $consumer->setIdleTimeoutExitCode(2);
+
+    $amqpChannel->expects($this->exactly(1))
+        ->method('wait')
+        ->with(null, false, $consumer->getIdleTimeout())
+        ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
+            $consumer->setLastActivityDateTime(new \DateTime("-$waitTimeout seconds"));
+            throw new AMQPTimeoutException();
+        });
+
+    expect($consumer->consume(1))->toBe(2);
+})->with('consumer_classes');
+
+test('consumption continues after idle timeout when force stop is false', function (string $consumerClass) {
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
+
+    $amqpChannel->method('getChannelId')->willReturn(true);
+    $amqpChannel->expects($this->once())->method('basic_consume')->withAnyParameters()->willReturn(true);
+    $amqpChannel->method('is_consuming')->willReturn(true);
+
+    $consumer = new $consumerClass($amqpConnection, $amqpChannel);
+    $consumer->disableAutoSetupFabric();
+    $consumer->setChannel($amqpChannel);
+    $consumer->setIdleTimeout(2);
+
+    $amqpChannel->expects($this->exactly(2))
+        ->method('wait')
+        ->with(null, false, $consumer->getIdleTimeout())
+        ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
+            $consumer->setLastActivityDateTime(new \DateTime("-$waitTimeout seconds"));
+            throw new AMQPTimeoutException();
+        });
+
+    $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->disableOriginalConstructor()->getMock();
+
+    $dispatchCallIndex = 0;
+    $eventDispatcher->expects($this->exactly(4))
+        ->method('dispatch')
+        ->willReturnCallback(function ($event, $eventName) use (&$dispatchCallIndex) {
+            if ($dispatchCallIndex === 1) {
+                expect($event)->toBeInstanceOf(OnIdleEvent::class);
+                $event->setForceStop(false);
+            } elseif ($dispatchCallIndex === 3) {
+                expect($event)->toBeInstanceOf(OnIdleEvent::class);
+                $event->setForceStop(true);
+            }
+            $dispatchCallIndex++;
+
+            return $event;
+        });
+
+    $consumer->setEventDispatcher($eventDispatcher);
+
+    expect(fn() => $consumer->consume(10))->toThrow(AMQPTimeoutException::class);
+})->with('consumer_classes');
+
+test('graceful max execution will not wait if past timeout', function (string $consumerClass) {
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
+
+    $amqpChannel->method('getChannelId')->willReturn(true);
+    $amqpChannel->expects($this->once())->method('basic_consume')->withAnyParameters()->willReturn(true);
+    $amqpChannel->method('is_consuming')->willReturn(true);
+
+    $consumer = new $consumerClass($amqpConnection, $amqpChannel);
+    $consumer->disableAutoSetupFabric();
+    $consumer->setChannel($amqpChannel);
+    $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture(0);
+
+    $amqpChannel->expects($this->never())->method('wait');
+
+    $consumer->consume(1);
+})->with('consumer_classes');
+
+test('timeout wait uses minimum of timeout wait and other timeouts', function (string $consumerClass) {
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
+
+    $amqpChannel->method('getChannelId')->willReturn(true);
+    $amqpChannel->expects($this->once())->method('basic_consume')->withAnyParameters()->willReturn(true);
+    $amqpChannel->method('is_consuming')->willReturn(true);
+
+    $consumer = new $consumerClass($amqpConnection, $amqpChannel);
+    $consumer->disableAutoSetupFabric();
+    $consumer->setChannel($amqpChannel);
+    $consumer->setTimeoutWait(30);
+    $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture(60);
+    $consumer->setIdleTimeout(50);
+
+    $amqpChannel->expects($this->exactly(2))
+        ->method('wait')
+        ->with(null, false, $this->lessThanOrEqual($consumer->getTimeoutWait()))
+        ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
+            $consumer->setGracefulMaxExecutionDateTime(
+                $consumer->getGracefulMaxExecutionDateTime()->modify("-$waitTimeout seconds")
             );
+            $consumer->setLastActivityDateTime(new \DateTime());
+            throw new AMQPTimeoutException();
+        });
 
-        $consumer->processMessage($amqpMessage);
-    }
+    $consumer->consume(1);
+})->with('consumer_classes');
 
-    public function processMessageProvider()
-    {
-        return [
-            [null, 'basic_ack'], // Remove message from queue only if callback return not false
-            [true, 'basic_ack'], // Remove message from queue only if callback return not false
-            [false, 'basic_reject', true], // Reject and requeue message to RabbitMQ
-            [ConsumerInterface::MSG_ACK, 'basic_ack'], // Remove message from queue only if callback return not false
-            [ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true], // Reject and requeue message to RabbitMQ
-            [ConsumerInterface::MSG_REJECT, 'basic_reject', false], // Reject and drop
-            [ConsumerInterface::MSG_ACK_SENT], // ack not sent by the consumer but should be sent by the implementer of ConsumerInterface
-        ];
-    }
+test('timeout wait will not wait past idle timeout', function (string $consumerClass) {
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
 
-    /**
-     * @return array
-     */
-    public function consumeProvider()
-    {
-        $testCases["All ok 4 callbacks"] = [
-            [
-                "messages" => [
-                    "msgCallback1",
-                    "msgCallback2",
-                    "msgCallback3",
-                    "msgCallback4",
-                ],
-            ],
-        ];
+    $amqpChannel->method('getChannelId')->willReturn(true);
+    $amqpChannel->expects($this->once())->method('basic_consume')->withAnyParameters()->willReturn(true);
+    $amqpChannel->method('is_consuming')->willReturn(true);
 
-        $testCases["No callbacks"] = [
-            [
-                "messages" => [],
-            ],
-        ];
+    $consumer = new $consumerClass($amqpConnection, $amqpChannel);
+    $consumer->disableAutoSetupFabric();
+    $consumer->setChannel($amqpChannel);
+    $consumer->setTimeoutWait(20);
+    $consumer->setIdleTimeout(10);
+    $consumer->setIdleTimeoutExitCode(2);
 
-        return $testCases;
-    }
+    $amqpChannel->expects($this->once())
+        ->method('wait')
+        ->with(null, false, 10)
+        ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
+            $consumer->setLastActivityDateTime(new \DateTime("-$waitTimeout seconds"));
+            throw new AMQPTimeoutException();
+        });
 
-    /**
-     * @dataProvider consumeProvider
-     *
-     * @param array $data
-     */
-    public function testConsume(array $data)
-    {
-        $messageCount = count($data['messages']);
-
-        // set up amqp connection
-        $amqpConnection = $this->prepareAMQPConnection();
-        // set up amqp channel
-        $amqpChannel = $this->prepareAMQPChannel();
-        $amqpChannel->expects($this->atLeastOnce())
-            ->method('getChannelId')
-            ->with()
-            ->willReturn(true);
-        $amqpChannel
-            ->expects($this->once())
-            ->method('basic_consume')
-            ->withAnyParameters()
-            ->willReturn(true);
-        $amqpChannel
-            ->expects(self::exactly(2))
-            ->method('is_consuming')
-            ->willReturnOnConsecutiveCalls(array_merge(array_fill(0, $messageCount, true), [false]));
-
-        // set up consumer
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-        // disable autosetup fabric so we do not mock more objects
-        $consumer->disableAutoSetupFabric();
-        $consumer->setChannel($amqpChannel);
-
-        /**
-         * Mock wait method and use a callback to remove one element each time from callbacks
-         * This will simulate a basic consumer consume with provided messages count
-         */
-        $amqpChannel
-            ->expects(self::exactly(1))
-            ->method('wait')
-            ->with(null, false, $consumer->getIdleTimeout())
-            ->willReturn(true);
-
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $eventDispatcher
-            ->expects(self::exactly(1))
-            ->method('dispatch')
-            ->with($this->isInstanceOf(OnConsumeEvent::class), OnConsumeEvent::NAME)
-            ->willReturn($this->isInstanceOf(OnConsumeEvent::class));
-
-        $consumer->setEventDispatcher($eventDispatcher);
-        $consumer->consume(1);
-    }
-
-    public function testIdleTimeoutExitCode()
-    {
-        // set up amqp connection
-        $amqpConnection = $this->prepareAMQPConnection();
-        // set up amqp channel
-        $amqpChannel = $this->prepareAMQPChannel();
-        $amqpChannel->expects($this->atLeastOnce())
-            ->method('getChannelId')
-            ->with()
-            ->willReturn(true);
-        $amqpChannel->expects($this->once())
-            ->method('basic_consume')
-            ->withAnyParameters()
-            ->willReturn(true);
-        $amqpChannel
-            ->expects($this->any())
-            ->method('is_consuming')
-            ->willReturn(true);
-
-        // set up consumer
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-        // disable autosetup fabric so we do not mock more objects
-        $consumer->disableAutoSetupFabric();
-        $consumer->setChannel($amqpChannel);
-        $consumer->setIdleTimeout(60);
-        $consumer->setIdleTimeoutExitCode(2);
-
-        $amqpChannel->expects($this->exactly(1))
-            ->method('wait')
-            ->with(null, false, $consumer->getIdleTimeout())
-            ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
-                // simulate time passing by moving the last activity date time
-                $consumer->setLastActivityDateTime(new \DateTime("-$waitTimeout seconds"));
-                throw new AMQPTimeoutException();
-            });
-
-        $this->assertTrue(2 == $consumer->consume(1));
-    }
-
-    public function testShouldAllowContinueConsumptionAfterIdleTimeout()
-    {
-        // set up amqp connection
-        $amqpConnection = $this->prepareAMQPConnection();
-        // set up amqp channel
-        $amqpChannel = $this->prepareAMQPChannel();
-        $amqpChannel->expects($this->atLeastOnce())
-            ->method('getChannelId')
-            ->with()
-            ->willReturn(true);
-        $amqpChannel->expects($this->once())
-            ->method('basic_consume')
-            ->withAnyParameters()
-            ->willReturn(true);
-        $amqpChannel
-            ->expects($this->any())
-            ->method('is_consuming')
-            ->willReturn(true);
-
-        // set up consumer
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-        // disable autosetup fabric so we do not mock more objects
-        $consumer->disableAutoSetupFabric();
-        $consumer->setChannel($amqpChannel);
-        $consumer->setIdleTimeout(2);
-
-        $amqpChannel->expects($this->exactly(2))
-            ->method('wait')
-            ->with(null, false, $consumer->getIdleTimeout())
-            ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
-                // simulate time passing by moving the last activity date time
-                $consumer->setLastActivityDateTime(new \DateTime("-$waitTimeout seconds"));
-                throw new AMQPTimeoutException();
-            });
-
-        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $eventDispatcher->expects($this->exactly(4))
-            ->method('dispatch')
-            ->withConsecutive(
-                [
-                    $this->isInstanceOf(OnConsumeEvent::class),
-                    OnConsumeEvent::NAME,
-                ],
-                [
-                    $this->callback(function (OnIdleEvent $event) {
-                        $event->setForceStop(false);
-
-                        return true;
-                    }),
-                    OnIdleEvent::NAME,
-                ],
-                [
-                    $this->isInstanceOf(OnConsumeEvent::class),
-                    OnConsumeEvent::NAME,
-                ],
-                [
-                    $this->callback(function (OnIdleEvent $event) {
-                        $event->setForceStop(true);
-
-                        return true;
-                    }),
-                    OnIdleEvent::NAME,
-                ]
-            );
-
-        $consumer->setEventDispatcher($eventDispatcher);
-
-        $this->expectException(AMQPTimeoutException::class);
-        $consumer->consume(10);
-    }
-    //TODO: try to understand the logic and fix the test
-    //    public function testGracefulMaxExecutionTimeoutExitCode()
-    //    {
-    //        // set up amqp connection
-    //        $amqpConnection = $this->prepareAMQPConnection();
-    //        // set up amqp channel
-    //        $amqpChannel = $this->prepareAMQPChannel();
-    //        $amqpChannel->expects($this->atLeastOnce())
-    //            ->method('getChannelId')
-    //            ->with()
-    //            ->willReturn(true);
-    //        $amqpChannel->expects($this->once())
-    //            ->method('basic_consume')
-    //            ->withAnyParameters()
-    //            ->willReturn(true);
-    //        $amqpChannel
-    //            ->expects($this->any())
-    //            ->method('is_consuming')
-    //            ->willReturn(true);
-    //
-    //        // set up consumer
-    //        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-    //        // disable autosetup fabric so we do not mock more objects
-    //        $consumer->disableAutoSetupFabric();
-    //        $consumer->setChannel($amqpChannel);
-    //        $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture(60);
-    //        $consumer->setGracefulMaxExecutionTimeoutExitCode(10);
-    //
-    //        $amqpChannel->expects($this->exactly(1))
-    //            ->method('wait')
-    //            ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
-    //                // simulate time passing by moving the max execution date time
-    //                $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture($waitTimeout * -1);
-    //                throw new AMQPTimeoutException();
-    //            });
-    //
-    //        $this->assertSame(10, $consumer->consume(1));
-    //    }
-
-    public function testGracefulMaxExecutionWontWaitIfPastTheTimeout()
-    {
-        // set up amqp connection
-        $amqpConnection = $this->prepareAMQPConnection();
-        // set up amqp channel
-        $amqpChannel = $this->prepareAMQPChannel();
-        $amqpChannel->expects($this->atLeastOnce())
-            ->method('getChannelId')
-            ->with()
-            ->willReturn(true);
-        $amqpChannel->expects($this->once())
-            ->method('basic_consume')
-            ->withAnyParameters()
-            ->willReturn(true);
-        $amqpChannel
-            ->expects($this->any())
-            ->method('is_consuming')
-            ->willReturn(true);
-
-        // set up consumer
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-        // disable autosetup fabric so we do not mock more objects
-        $consumer->disableAutoSetupFabric();
-        $consumer->setChannel($amqpChannel);
-
-        $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture(0);
-
-        $amqpChannel
-            ->expects($this->never())
-            ->method('wait');
-
-        $consumer->consume(1);
-    }
-
-    public function testTimeoutWait()
-    {
-        // set up amqp connection
-        $amqpConnection = $this->prepareAMQPConnection();
-        // set up amqp channel
-        $amqpChannel = $this->prepareAMQPChannel();
-        $amqpChannel->expects($this->atLeastOnce())
-            ->method('getChannelId')
-            ->with()
-            ->willReturn(true);
-        $amqpChannel->expects($this->once())
-            ->method('basic_consume')
-            ->withAnyParameters()
-            ->willReturn(true);
-        $amqpChannel
-            ->expects($this->any())
-            ->method('is_consuming')
-            ->willReturn(true);
-
-        // set up consumer
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-        // disable autosetup fabric so we do not mock more objects
-        $consumer->disableAutoSetupFabric();
-        $consumer->setChannel($amqpChannel);
-        $consumer->setTimeoutWait(30);
-        $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture(60);
-        $consumer->setIdleTimeout(50);
-
-        $amqpChannel->expects($this->exactly(2))
-            ->method('wait')
-            ->with(null, false, $this->LessThanOrEqual($consumer->getTimeoutWait()))
-            ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
-                // ensure max execution date time "counts down"
-                $consumer->setGracefulMaxExecutionDateTime(
-                    $consumer->getGracefulMaxExecutionDateTime()->modify("-$waitTimeout seconds")
-                );
-                // ensure last activity just occurred so idle timeout is not reached
-                $consumer->setLastActivityDateTime(new \DateTime());
-                throw new AMQPTimeoutException();
-            });
-
-        $consumer->consume(1);
-    }
-    //TODO: try to understand the logic and fix the test
-    //    public function testTimeoutWaitWontWaitPastGracefulMaxExecutionTimeout()
-    //    {
-    //        // set up amqp connection
-    //        $amqpConnection = $this->prepareAMQPConnection();
-    //        // set up amqp channel
-    //        $amqpChannel = $this->prepareAMQPChannel();
-    //        $amqpChannel->expects($this->atLeastOnce())
-    //            ->method('getChannelId')
-    //            ->with()
-    //            ->willReturn(true);
-    //        $amqpChannel->expects($this->once())
-    //            ->method('basic_consume')
-    //            ->withAnyParameters()
-    //            ->willReturn(true);
-    //        $amqpChannel
-    //            ->expects($this->any())
-    //            ->method('is_consuming')
-    //            ->willReturn(true);
-    //
-    //        // set up consumer
-    //        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-    //        // disable autosetup fabric so we do not mock more objects
-    //        $consumer->disableAutoSetupFabric();
-    //        $consumer->setChannel($amqpChannel);
-    //        $consumer->setTimeoutWait(20);
-    //
-    //        $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture(10);
-    //
-    //        $amqpChannel->expects($this->once())
-    //            ->method('wait')
-    //            ->with(null, false, $consumer->getGracefulMaxExecutionDateTime()->diff(new \DateTime())->s)
-    //            ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
-    //                // simulate time passing by moving the max execution date time
-    //                $consumer->setGracefulMaxExecutionDateTimeFromSecondsInTheFuture($waitTimeout * -1);
-    //                throw new AMQPTimeoutException();
-    //            });
-    //
-    //        $consumer->consume(1);
-    //    }
-
-    public function testTimeoutWaitWontWaitPastIdleTimeout()
-    {
-        // set up amqp connection
-        $amqpConnection = $this->prepareAMQPConnection();
-        // set up amqp channel
-        $amqpChannel = $this->prepareAMQPChannel();
-        $amqpChannel->expects($this->atLeastOnce())
-            ->method('getChannelId')
-            ->with()
-            ->willReturn(true);
-        $amqpChannel->expects($this->once())
-            ->method('basic_consume')
-            ->withAnyParameters()
-            ->willReturn(true);
-        $amqpChannel
-            ->expects($this->any())
-            ->method('is_consuming')
-            ->willReturn(true);
-
-        // set up consumer
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-        // disable autosetup fabric so we do not mock more objects
-        $consumer->disableAutoSetupFabric();
-        $consumer->setChannel($amqpChannel);
-        $consumer->setTimeoutWait(20);
-        $consumer->setIdleTimeout(10);
-        $consumer->setIdleTimeoutExitCode(2);
-
-        $amqpChannel->expects($this->once())
-            ->method('wait')
-            ->with(null, false, 10)
-            ->willReturnCallback(function ($allowedMethods, $nonBlocking, $waitTimeout) use ($consumer) {
-                // simulate time passing by moving the last activity date time
-                $consumer->setLastActivityDateTime(new \DateTime("-$waitTimeout seconds"));
-                throw new AMQPTimeoutException();
-            });
-
-        $this->assertEquals(2, $consumer->consume(1));
-    }
-}
+    expect($consumer->consume(1))->toBe(2);
+})->with('consumer_classes');

--- a/Tests/RabbitMq/DynamicConsumerTest.php
+++ b/Tests/RabbitMq/DynamicConsumerTest.php
@@ -1,53 +1,28 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
-use OldSound\RabbitMqBundle\Provider\QueueOptionsProviderInterface;
 use OldSound\RabbitMqBundle\RabbitMq\DynamicConsumer;
-use PHPUnit\Framework\MockObject\MockObject;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
-class DynamicConsumerTest extends ConsumerTest
-{
-    public function getConsumer($amqpConnection, $amqpChannel)
-    {
-        return new DynamicConsumer($amqpConnection, $amqpChannel);
-    }
+test('queue options provider merges queue options', function () {
+    $amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
 
-    /**
-     * Preparing QueueOptionsProviderInterface instance
-     *
-     * @return MockObject|QueueOptionsProviderInterface
-     */
-    private function prepareQueueOptionsProvider()
-    {
-        return $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueueOptionsProviderInterface')
-            ->getMock();
-    }
+    $consumer = new DynamicConsumer($amqpConnection, $amqpChannel);
+    $consumer->setContext('foo');
 
-    public function testQueueOptionsPrivider()
-    {
-        $amqpConnection = $this->prepareAMQPConnection();
-        $amqpChannel = $this->prepareAMQPChannel();
-        $consumer = $this->getConsumer($amqpConnection, $amqpChannel);
-        $consumer->setContext('foo');
+    $queueOptionsProvider = $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueueOptionsProviderInterface')->getMock();
+    $queueOptionsProvider->expects($this->once())
+        ->method('getQueueOptions')
+        ->willReturn([
+            'name'         => 'queue_foo',
+            'routing_keys' => ['foo.*'],
+        ]);
 
-        $queueOptionsProvider = $this->prepareQueueOptionsProvider();
-        $queueOptionsProvider->expects($this->once())
-            ->method('getQueueOptions')
-            ->will($this->returnValue(
-                [
-                    'name' => 'queue_foo',
-                    'routing_keys' => [
-                        'foo.*',
-                    ],
-                ]
-            ));
+    $consumer->setQueueOptionsProvider($queueOptionsProvider);
 
-        $consumer->setQueueOptionsProvider($queueOptionsProvider);
-
-        $reflectionClass = new \ReflectionClass(get_class($consumer));
-        $reflectionMethod = $reflectionClass->getMethod('mergeQueueOptions');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($consumer);
-    }
-}
+    $reflectionClass  = new \ReflectionClass(DynamicConsumer::class);
+    $reflectionMethod = $reflectionClass->getMethod('mergeQueueOptions');
+    $reflectionMethod->setAccessible(true);
+    $reflectionMethod->invoke($consumer);
+});

--- a/Tests/RabbitMq/MultipleConsumerTest.php
+++ b/Tests/RabbitMq/MultipleConsumerTest.php
@@ -22,7 +22,7 @@ dataset('multiple_consumer_process_flags', [
 ]);
 
 test('process queue message acks or rejects according to callback return value', function (mixed $processFlag, string $expectedMethod, ?bool $expectedRequeue) {
-    $callback = static fn() => $processFlag;
+    $callback = static fn () => $processFlag;
 
     $this->consumer->setQueues([
         'test-1' => ['callback' => $callback],
@@ -45,7 +45,7 @@ test('process queue message acks or rejects according to callback return value',
 })->with('multiple_consumer_process_flags');
 
 test('queues provider is used when set', function (mixed $processFlag, string $expectedMethod, ?bool $expectedRequeue) {
-    $callback = static fn() => $processFlag;
+    $callback = static fn () => $processFlag;
 
     $queuesProvider = $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueuesProviderInterface')->getMock();
     $queuesProvider->expects($this->once())
@@ -78,7 +78,7 @@ test('queues provider is used when set', function (mixed $processFlag, string $e
 })->with('multiple_consumer_process_flags');
 
 test('queues provider and static queues are merged together', function (mixed $processFlag, string $expectedMethod, ?bool $expectedRequeue) {
-    $callback = static fn() => $processFlag;
+    $callback = static fn () => $processFlag;
 
     $this->consumer->setQueues([
         'test-1' => ['callback' => $callback],

--- a/Tests/RabbitMq/MultipleConsumerTest.php
+++ b/Tests/RabbitMq/MultipleConsumerTest.php
@@ -1,297 +1,160 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
-use OldSound\RabbitMqBundle\Provider\QueuesProviderInterface;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
-use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
-class MultipleConsumerTest extends TestCase
-{
-    /**
-     * Multiple consumer
-     *
-     * @var MultipleConsumer
-     */
-    private $multipleConsumer;
+beforeEach(function () {
+    $this->amqpConnection = $this->getMockBuilder(AMQPStreamConnection::class)->disableOriginalConstructor()->getMock();
+    $this->amqpChannel    = $this->getMockBuilder(AMQPChannel::class)->disableOriginalConstructor()->getMock();
+    $this->consumer       = new MultipleConsumer($this->amqpConnection, $this->amqpChannel);
+});
 
-    /**
-     * AMQP channel
-     *
-     * @var MockObject|AMQPChannel
-     */
-    private $amqpChannel;
+dataset('multiple_consumer_process_flags', [
+    'ack on null return'                        => [null,                              'basic_ack',    null],
+    'ack on true return'                        => [true,                              'basic_ack',    null],
+    'reject and requeue on false'               => [false,                             'basic_reject', true],
+    'ack on MSG_ACK'                            => [ConsumerInterface::MSG_ACK,        'basic_ack',    null],
+    'reject and requeue on MSG_REJECT_REQUEUE'  => [ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true],
+    'reject and drop on MSG_REJECT'             => [ConsumerInterface::MSG_REJECT,     'basic_reject', false],
+]);
 
-    /**
-     * AMQP connection
-     *
-     * @var MockObject|AMQPStreamConnection
-     */
-    private $amqpConnection;
+test('process queue message acks or rejects according to callback return value', function (mixed $processFlag, string $expectedMethod, ?bool $expectedRequeue) {
+    $callback = static fn() => $processFlag;
 
-    /**
-     * Set up
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        $this->amqpConnection = $this->prepareAMQPConnection();
-        $this->amqpChannel = $this->prepareAMQPChannel();
-        $this->multipleConsumer = new MultipleConsumer($this->amqpConnection, $this->amqpChannel);
-    }
+    $this->consumer->setQueues([
+        'test-1' => ['callback' => $callback],
+        'test-2' => ['callback' => $callback],
+    ]);
 
-    /**
-     * Check if the message is requeued or not correctly.
-     *
-     * @dataProvider processMessageProvider
-     */
-    public function testProcessMessage($processFlag, $expectedMethod, $expectedRequeue = null)
-    {
-        $callback = $this->prepareCallback($processFlag);
+    $this->amqpChannel->method('basic_reject')
+        ->willReturnCallback(function ($tag, $requeue) use ($expectedMethod, $expectedRequeue) {
+            expect($expectedMethod)->toBe('basic_reject');
+            expect($requeue)->toBe($expectedRequeue);
+        });
 
-        $this->multipleConsumer->setQueues(
-            [
-                'test-1' => ['callback' => $callback],
-                'test-2' => ['callback' => $callback],
-            ]
-        );
+    $this->amqpChannel->method('basic_ack')
+        ->willReturnCallback(function () use ($expectedMethod) {
+            expect($expectedMethod)->toBe('basic_ack');
+        });
 
-        $this->prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue);
+    $this->consumer->processQueueMessage('test-1', createMultipleConsumerTestMessage($this->amqpChannel));
+    $this->consumer->processQueueMessage('test-2', createMultipleConsumerTestMessage($this->amqpChannel));
+})->with('multiple_consumer_process_flags');
 
-        $this->multipleConsumer->processQueueMessage('test-1', $this->createMessage());
-        $this->multipleConsumer->processQueueMessage('test-2', $this->createMessage());
-    }
+test('queues provider is used when set', function (mixed $processFlag, string $expectedMethod, ?bool $expectedRequeue) {
+    $callback = static fn() => $processFlag;
 
-    /**
-     * Check queues provider works well
-     *
-     * @dataProvider processMessageProvider
-     */
-    public function testQueuesProvider($processFlag, $expectedMethod, $expectedRequeue = null)
-    {
-        $callback = $this->prepareCallback($processFlag);
-
-        $queuesProvider = $this->prepareQueuesProvider();
-        $queuesProvider->expects($this->once())
-            ->method('getQueues')
-            ->will($this->returnValue(
-                [
-                    'test-1' => ['callback' => $callback],
-                    'test-2' => ['callback' => $callback],
-                ]
-            ));
-
-        $this->multipleConsumer->setQueuesProvider($queuesProvider);
-
-        /**
-         * We don't test consume method, which merges queues by calling $this->setupConsumer();
-         * So we need to invoke it manually
-         */
-        $reflectionClass = new \ReflectionClass(get_class($this->multipleConsumer));
-        $reflectionMethod = $reflectionClass->getMethod('mergeQueues');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($this->multipleConsumer);
-
-        $this->prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue);
-
-        $this->multipleConsumer->processQueueMessage('test-1', $this->createMessage());
-        $this->multipleConsumer->processQueueMessage('test-2', $this->createMessage());
-    }
-
-    /**
-     * Check queues provider works well with static queues together
-     *
-     * @dataProvider processMessageProvider
-     */
-    public function testQueuesProviderAndStaticQueuesTogether($processFlag, $expectedMethod, $expectedRequeue = null)
-    {
-        $callback = $this->prepareCallback($processFlag);
-
-        $this->multipleConsumer->setQueues(
-            [
-                'test-1' => ['callback' => $callback],
-                'test-2' => ['callback' => $callback],
-            ]
-        );
-
-        $queuesProvider = $this->prepareQueuesProvider();
-        $queuesProvider->expects($this->once())
-            ->method('getQueues')
-            ->will($this->returnValue(
-                [
-                    'test-3' => ['callback' => $callback],
-                    'test-4' => ['callback' => $callback],
-                ]
-            ));
-
-        $this->multipleConsumer->setQueuesProvider($queuesProvider);
-
-        /**
-         * We don't test consume method, which merges queues by calling $this->setupConsumer();
-         * So we need to invoke it manually
-         */
-        $reflectionClass = new \ReflectionClass(get_class($this->multipleConsumer));
-        $reflectionMethod = $reflectionClass->getMethod('mergeQueues');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($this->multipleConsumer);
-
-        $this->prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue);
-
-        $this->multipleConsumer->processQueueMessage('test-1', $this->createMessage());
-        $this->multipleConsumer->processQueueMessage('test-2', $this->createMessage());
-        $this->multipleConsumer->processQueueMessage('test-3', $this->createMessage());
-        $this->multipleConsumer->processQueueMessage('test-4', $this->createMessage());
-    }
-
-    public function processMessageProvider()
-    {
-        return [
-            [null, 'basic_ack'], // Remove message from queue only if callback return not false
-            [true, 'basic_ack'], // Remove message from queue only if callback return not false
-            [false, 'basic_reject', true], // Reject and requeue message to RabbitMQ
-            [ConsumerInterface::MSG_ACK, 'basic_ack'], // Remove message from queue only if callback return not false
-            [ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true], // Reject and requeue message to RabbitMQ
-            [ConsumerInterface::MSG_REJECT, 'basic_reject', false], // Reject and drop
-        ];
-    }
-
-    /**
-     * @dataProvider queueBindingRoutingKeyProvider
-     */
-    public function testShouldConsiderQueueArgumentsOnQueueDeclaration($routingKeysOption, $expectedRoutingKey)
-    {
-        $queueName = 'test-queue-name';
-        $exchangeName = 'test-exchange-name';
-        $expectedArgs = ['test-argument' => ['S', 'test-value']];
-
-        $this->amqpChannel->expects($this->any())
-            ->method('getChannelId')->willReturn(0);
-
-        $this->amqpChannel->expects($this->any())
-            ->method('queue_declare')
-            ->willReturn([$queueName, 5, 0]);
-
-
-        $this->multipleConsumer->setExchangeOptions([
-            'declare' => false,
-            'name' => $exchangeName,
-            'type' => 'topic', ]);
-
-        $this->multipleConsumer->setQueues([
-            $queueName => [
-                'passive' => true,
-                'durable' => true,
-                'exclusive' => true,
-                'auto_delete' => true,
-                'nowait' => true,
-                'arguments' => $expectedArgs,
-                'ticket' => null,
-                'routing_keys' => $routingKeysOption, ],
+    $queuesProvider = $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueuesProviderInterface')->getMock();
+    $queuesProvider->expects($this->once())
+        ->method('getQueues')
+        ->willReturn([
+            'test-1' => ['callback' => $callback],
+            'test-2' => ['callback' => $callback],
         ]);
 
-        $this->multipleConsumer->setRoutingKey('test-routing-key');
+    $this->consumer->setQueuesProvider($queuesProvider);
 
-        // we assert that arguments are passed to the bind method
-        $this->amqpChannel->expects($this->once())
-            ->method('queue_bind')
-            ->with($queueName, $exchangeName, $expectedRoutingKey, false, $expectedArgs);
+    $reflectionClass  = new \ReflectionClass(MultipleConsumer::class);
+    $reflectionMethod = $reflectionClass->getMethod('mergeQueues');
+    $reflectionMethod->setAccessible(true);
+    $reflectionMethod->invoke($this->consumer);
 
-        $this->multipleConsumer->setupFabric();
-    }
+    $this->amqpChannel->method('basic_reject')
+        ->willReturnCallback(function ($tag, $requeue) use ($expectedMethod, $expectedRequeue) {
+            expect($expectedMethod)->toBe('basic_reject');
+            expect($requeue)->toBe($expectedRequeue);
+        });
 
-    public function queueBindingRoutingKeyProvider()
-    {
-        return [
-            [[], 'test-routing-key'],
-            [['test-routing-key-2'], 'test-routing-key-2'],
-        ];
-    }
+    $this->amqpChannel->method('basic_ack')
+        ->willReturnCallback(function () use ($expectedMethod) {
+            expect($expectedMethod)->toBe('basic_ack');
+        });
 
-    /**
-     * Preparing AMQP Connection
-     *
-     * @return MockObject|AMQPStreamConnection
-     */
-    private function prepareAMQPConnection()
-    {
-        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
+    $this->consumer->processQueueMessage('test-1', createMultipleConsumerTestMessage($this->amqpChannel));
+    $this->consumer->processQueueMessage('test-2', createMultipleConsumerTestMessage($this->amqpChannel));
+})->with('multiple_consumer_process_flags');
 
-    /**
-     * Preparing AMQP Connection
-     *
-     * @return MockObject|AMQPChannel
-     */
-    private function prepareAMQPChannel()
-    {
-        return $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
+test('queues provider and static queues are merged together', function (mixed $processFlag, string $expectedMethod, ?bool $expectedRequeue) {
+    $callback = static fn() => $processFlag;
 
-    /**
-     * Preparing QueuesProviderInterface instance
-     *
-     * @return MockObject|QueuesProviderInterface
-     */
-    private function prepareQueuesProvider()
-    {
-        return $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueuesProviderInterface')
-            ->getMock();
-    }
+    $this->consumer->setQueues([
+        'test-1' => ['callback' => $callback],
+        'test-2' => ['callback' => $callback],
+    ]);
 
-    /**
-     * Preparing AMQP Channel Expectations
-     *
-     * @param mixed $expectedMethod
-     * @param string $expectedRequeue
-     *
-     * @return void
-     */
-    private function prepareAMQPChannelExpectations($expectedMethod, $expectedRequeue)
-    {
-        $this->amqpChannel->expects($this->any())
-            ->method('basic_reject')
-            ->will($this->returnCallback(function ($delivery_tag, $requeue) use ($expectedMethod, $expectedRequeue) {
-                Assert::assertSame($expectedMethod, 'basic_reject'); // Check if this function should be called.
-                Assert::assertSame($requeue, $expectedRequeue); // Check if the message should be requeued.
-            }));
+    $queuesProvider = $this->getMockBuilder('\OldSound\RabbitMqBundle\Provider\QueuesProviderInterface')->getMock();
+    $queuesProvider->expects($this->once())
+        ->method('getQueues')
+        ->willReturn([
+            'test-3' => ['callback' => $callback],
+            'test-4' => ['callback' => $callback],
+        ]);
 
-        $this->amqpChannel->expects($this->any())
-            ->method('basic_ack')
-            ->will($this->returnCallback(function ($delivery_tag) use ($expectedMethod) {
-                Assert::assertSame($expectedMethod, 'basic_ack'); // Check if this function should be called.
-            }));
-    }
+    $this->consumer->setQueuesProvider($queuesProvider);
 
-    /**
-     * Prepare callback
-     *
-     * @param bool $processFlag
-     * @return callable
-     */
-    private function prepareCallback($processFlag)
-    {
-        return function ($msg) use ($processFlag) {
-            return $processFlag;
-        };
-    }
+    $reflectionClass  = new \ReflectionClass(MultipleConsumer::class);
+    $reflectionMethod = $reflectionClass->getMethod('mergeQueues');
+    $reflectionMethod->setAccessible(true);
+    $reflectionMethod->invoke($this->consumer);
 
-    private function createMessage()
-    {
-        $amqpMessage = new AMQPMessage('foo body');
-        $amqpMessage->setChannel($this->amqpChannel);
-        $amqpMessage->setDeliveryTag(0);
+    $this->amqpChannel->method('basic_reject')
+        ->willReturnCallback(function ($tag, $requeue) use ($expectedMethod, $expectedRequeue) {
+            expect($expectedMethod)->toBe('basic_reject');
+            expect($requeue)->toBe($expectedRequeue);
+        });
 
-        return $amqpMessage;
-    }
+    $this->amqpChannel->method('basic_ack')
+        ->willReturnCallback(function () use ($expectedMethod) {
+            expect($expectedMethod)->toBe('basic_ack');
+        });
+
+    $this->consumer->processQueueMessage('test-1', createMultipleConsumerTestMessage($this->amqpChannel));
+    $this->consumer->processQueueMessage('test-2', createMultipleConsumerTestMessage($this->amqpChannel));
+    $this->consumer->processQueueMessage('test-3', createMultipleConsumerTestMessage($this->amqpChannel));
+    $this->consumer->processQueueMessage('test-4', createMultipleConsumerTestMessage($this->amqpChannel));
+})->with('multiple_consumer_process_flags');
+
+test('queue declaration passes queue arguments to bind', function (array $routingKeysOption, string $expectedRoutingKey) {
+    $queueName    = 'test-queue-name';
+    $exchangeName = 'test-exchange-name';
+    $expectedArgs = ['test-argument' => ['S', 'test-value']];
+
+    $this->amqpChannel->method('getChannelId')->willReturn(0);
+    $this->amqpChannel->method('queue_declare')->willReturn([$queueName, 5, 0]);
+
+    $this->consumer->setExchangeOptions(['declare' => false, 'name' => $exchangeName, 'type' => 'topic']);
+    $this->consumer->setQueues([
+        $queueName => [
+            'passive'      => true,
+            'durable'      => true,
+            'exclusive'    => true,
+            'auto_delete'  => true,
+            'nowait'       => true,
+            'arguments'    => $expectedArgs,
+            'ticket'       => null,
+            'routing_keys' => $routingKeysOption,
+        ],
+    ]);
+    $this->consumer->setRoutingKey('test-routing-key');
+
+    $this->amqpChannel->expects($this->once())
+        ->method('queue_bind')
+        ->with($queueName, $exchangeName, $expectedRoutingKey, false, $expectedArgs);
+
+    $this->consumer->setupFabric();
+})->with([
+    'uses consumer routing key when queue has none' => [[], 'test-routing-key'],
+    'uses queue-specific routing key'               => [['test-routing-key-2'], 'test-routing-key-2'],
+]);
+
+function createMultipleConsumerTestMessage(mixed $channel): AMQPMessage
+{
+    $message = new AMQPMessage('foo body');
+    $message->setChannel($channel);
+    $message->setDeliveryTag(0);
+
+    return $message;
 }

--- a/Tests/RabbitMq/RpcClientTest.php
+++ b/Tests/RabbitMq/RpcClientTest.php
@@ -1,98 +1,81 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
-use InvalidArgumentException;
 use OldSound\RabbitMqBundle\RabbitMq\RpcClient;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
-use PHPUnit\Framework\TestCase;
 
-class RpcClientTest extends TestCase
-{
-    public function testProcessMessageWithCustomUnserializer()
-    {
-        /** @var RpcClient $client */
-        $client = $this->getMockBuilder('\OldSound\RabbitMqBundle\RabbitMq\RpcClient')
-            ->setMethods(['sendReply', 'maybeStopConsumer'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        /** @var AMQPMessage $message */
-        $message = $this->getMockBuilder('\PhpAmqpLib\Message\AMQPMessage')
-            ->setMethods(['get'])
-            ->setConstructorArgs(['message'])
-            ->getMock();
-        $serializer = $this->getMockBuilder('\Symfony\Component\Serializer\SerializerInterface')
-            ->setMethods(['serialize', 'deserialize'])
-            ->getMock();
-        $serializer->expects($this->once())->method('deserialize')->with('message', 'json', null);
-        $client->initClient(true);
-        $client->setUnserializer(function ($data) use ($serializer) {
-            $serializer->deserialize($data, 'json', '');
-        });
-        $client->processMessage($message);
-    }
+test('process message uses custom unserializer when set', function () {
+    // onlyMethods([]) keeps all real implementations so processMessage() runs actual code
+    $client = $this->getMockBuilder(RpcClient::class)
+        ->onlyMethods([])
+        ->disableOriginalConstructor()
+        ->getMock();
 
-    public function testProcessMessageWithNotifyMethod()
-    {
-        /** @var RpcClient $client */
-        $client = $this->getMockBuilder('\OldSound\RabbitMqBundle\RabbitMq\RpcClient')
-            ->setMethods(['sendReply', 'maybeStopConsumer'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $expectedNotify = 'message';
-        /** @var AMQPMessage $message */
-        $message = $this->getMockBuilder('\PhpAmqpLib\Message\AMQPMessage')
-            ->setMethods(['get'])
-            ->setConstructorArgs([$expectedNotify])
-            ->getMock();
-        $notified = false;
-        $client->notify(function ($message) use (&$notified) {
-            $notified = $message;
-        });
+    $message = $this->getMockBuilder(AMQPMessage::class)
+        ->onlyMethods(['get'])
+        ->setConstructorArgs(['message'])
+        ->getMock();
 
-        $client->initClient(false);
-        $client->processMessage($message);
+    $serializer = $this->getMockBuilder('\Symfony\Component\Serializer\SerializerInterface')->getMock();
+    $serializer->expects($this->once())->method('deserialize')->with('message', 'json', null);
 
-        $this->assertSame($expectedNotify, $notified);
-    }
+    $client->initClient(true);
+    $client->setUnserializer(function ($data) use ($serializer) {
+        $serializer->deserialize($data, 'json', '');
+    });
 
-    public function testInvalidParameterOnNotify()
-    {
-        /** @var RpcClient $client */
-        $client = $this->getMockBuilder('\OldSound\RabbitMqBundle\RabbitMq\RpcClient')
-            ->setMethods(['sendReply', 'maybeStopConsumer'])
-            ->disableOriginalConstructor()
-            ->getMock();
+    $client->processMessage($message);
+});
 
-        $this->expectException(InvalidArgumentException::class);
+test('process message calls notify callback with message body', function () {
+    // onlyMethods([]) keeps all real implementations so processMessage() and notify() run actual code
+    $client = $this->getMockBuilder(RpcClient::class)
+        ->onlyMethods([])
+        ->disableOriginalConstructor()
+        ->getMock();
 
-        $client->notify('not a callable');
-    }
+    $expectedBody = 'message';
 
-    public function testChannelCancelOnGetRepliesException()
-    {
-        $client = $this->getMockBuilder('\OldSound\RabbitMqBundle\RabbitMq\RpcClient')
-            ->setMethods(null)
-            ->disableOriginalConstructor()
-            ->getMock();
+    $message = $this->getMockBuilder(AMQPMessage::class)
+        ->onlyMethods(['get'])
+        ->setConstructorArgs([$expectedBody])
+        ->getMock();
 
-        $channel = $this->createMock('\PhpAmqpLib\Channel\AMQPChannel');
-        $channel->expects($this->any())
-            ->method('getChannelId')
-            ->willReturn('test');
-        $channel->expects($this->once())
-            ->method('wait')
-            ->willThrowException(new AMQPTimeoutException());
+    $notified = false;
+    $client->notify(function ($msg) use (&$notified) {
+        $notified = $msg;
+    });
 
-        $this->expectException(AMQPTimeoutException::class);
+    $client->initClient(false);
+    $client->processMessage($message);
 
-        $channel->expects($this->once())
-            ->method('basic_cancel');
+    expect($notified)->toBe($expectedBody);
+});
 
-        $client->setChannel($channel);
-        $client->addRequest('a', 'b', 'c');
+test('notify throws when given a non-callable', function () {
+    // onlyMethods([]) keeps all real implementations so notify() throws as expected
+    $client = $this->getMockBuilder(RpcClient::class)
+        ->onlyMethods([])
+        ->disableOriginalConstructor()
+        ->getMock();
 
-        $client->getReplies();
-    }
-}
+    expect(fn() => $client->notify('not a callable'))->toThrow(\InvalidArgumentException::class);
+});
+
+test('channel is cancelled when getReplies throws an exception', function () {
+    // onlyMethods([]) keeps all real implementations so getReplies() runs actual code
+    $client = $this->getMockBuilder(RpcClient::class)
+        ->onlyMethods([])
+        ->disableOriginalConstructor()
+        ->getMock();
+
+    $channel = $this->createMock('\PhpAmqpLib\Channel\AMQPChannel');
+    $channel->method('getChannelId')->willReturn('test');
+    $channel->expects($this->once())->method('wait')->willThrowException(new AMQPTimeoutException());
+    $channel->expects($this->once())->method('basic_cancel');
+
+    $client->setChannel($channel);
+    $client->addRequest('a', 'b', 'c');
+
+    expect(fn() => $client->getReplies())->toThrow(AMQPTimeoutException::class);
+});

--- a/Tests/RabbitMq/RpcClientTest.php
+++ b/Tests/RabbitMq/RpcClientTest.php
@@ -59,7 +59,7 @@ test('notify throws when given a non-callable', function () {
         ->disableOriginalConstructor()
         ->getMock();
 
-    expect(fn() => $client->notify('not a callable'))->toThrow(\InvalidArgumentException::class);
+    expect(fn () => $client->notify('not a callable'))->toThrow(\InvalidArgumentException::class);
 });
 
 test('channel is cancelled when getReplies throws an exception', function () {
@@ -77,5 +77,5 @@ test('channel is cancelled when getReplies throws an exception', function () {
     $client->setChannel($channel);
     $client->addRequest('a', 'b', 'c');
 
-    expect(fn() => $client->getReplies())->toThrow(AMQPTimeoutException::class);
+    expect(fn () => $client->getReplies())->toThrow(AMQPTimeoutException::class);
 });

--- a/Tests/RabbitMq/RpcServerTest.php
+++ b/Tests/RabbitMq/RpcServerTest.php
@@ -20,7 +20,7 @@ test('process message uses custom serializer when set', function () {
     $message->setChannel($channel);
     $message->setDeliveryTag(0);
 
-    $server->setCallback(static fn() => 'message');
+    $server->setCallback(static fn () => 'message');
 
     $serializer = $this->getMockBuilder('\Symfony\Component\Serializer\SerializerInterface')->getMock();
     $serializer->expects($this->once())->method('serialize')->with('message', 'json');

--- a/Tests/RabbitMq/RpcServerTest.php
+++ b/Tests/RabbitMq/RpcServerTest.php
@@ -1,41 +1,33 @@
 <?php
 
-namespace OldSound\RabbitMqBundle\Tests\RabbitMq;
-
 use OldSound\RabbitMqBundle\RabbitMq\RpcServer;
 use PhpAmqpLib\Message\AMQPMessage;
-use PHPUnit\Framework\TestCase;
 
-class RpcServerTest extends TestCase
-{
-    public function testProcessMessageWithCustomSerializer()
-    {
-        /** @var RpcServer $server */
-        $server = $this->getMockBuilder('\OldSound\RabbitMqBundle\RabbitMq\RpcServer')
-            ->setMethods(['sendReply', 'maybeStopConsumer'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $message = $this->getMockBuilder('\PhpAmqpLib\Message\AMQPMessage')
-            ->setMethods(['get'])
-            ->getMock();
-        $message->setChannel(
-            $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-                ->setMethods([])->setConstructorArgs([])
-                ->setMockClassName('')
-                ->disableOriginalConstructor()
-                ->getMock()
-        );
-        $message->setDeliveryTag(0);
-        $server->setCallback(function () {
-            return 'message';
-        });
-        $serializer = $this->getMockBuilder('\Symfony\Component\Serializer\SerializerInterface')
-            ->setMethods(['serialize', 'deserialize'])
-            ->getMock();
-        $serializer->expects($this->once())->method('serialize')->with('message', 'json');
-        $server->setSerializer(function ($data) use ($serializer) {
-            $serializer->serialize($data, 'json');
-        });
-        $server->processMessage($message);
-    }
-}
+test('process message uses custom serializer when set', function () {
+    $server = $this->getMockBuilder(RpcServer::class)
+        ->onlyMethods(['sendReply', 'maybeStopConsumer'])
+        ->disableOriginalConstructor()
+        ->getMock();
+
+    $message = $this->getMockBuilder(AMQPMessage::class)
+        ->onlyMethods(['get'])
+        ->getMock();
+
+    $channel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+        ->disableOriginalConstructor()
+        ->getMock();
+
+    $message->setChannel($channel);
+    $message->setDeliveryTag(0);
+
+    $server->setCallback(static fn() => 'message');
+
+    $serializer = $this->getMockBuilder('\Symfony\Component\Serializer\SerializerInterface')->getMock();
+    $serializer->expects($this->once())->method('serialize')->with('message', 'json');
+
+    $server->setSerializer(function ($data) use ($serializer) {
+        $serializer->serialize($data, 'json');
+    });
+
+    $server->processMessage($message);
+});

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "symfony/serializer":           "^6.0 || ^7.0 || ^8.0",
-        "pestphp/pest":                 "^3.0",
+        "pestphp/pest":                 "^2.0 || ^3.0",
         "phpstan/phpstan":              "^1.2",
         "phpstan/phpstan-phpunit":      "^1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     },
     "require-dev": {
         "symfony/serializer":           "^6.0 || ^7.0 || ^8.0",
-        "phpunit/phpunit":              "^9.5",
+        "pestphp/pest":                 "^3.0",
         "phpstan/phpstan":              "^1.2",
-        "phpstan/phpstan-phpunit":      "^1.0"
+        "phpstan/phpstan-phpunit":      "^1.4"
     },
     "replace": {
         "oldsound/rabbitmq-bundle": "self.version",
@@ -49,6 +49,11 @@
     "autoload-dev": {
         "psr-4": {
             "OldSound\\RabbitMqBundle\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
         }
     }
 }

--- a/pest.php
+++ b/pest.php
@@ -1,0 +1,3 @@
+<?php
+
+uses(\PHPUnit\Framework\TestCase::class)->in('Tests');

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,12 +13,9 @@ parameters:
         - Provider
         - RabbitMq
         - Resources
-        - Tests
         - OldSoundRabbitMqBundle.php
     ignoreErrors:
         - '#Call to an undefined method Symfony\\Component\\DependencyInjection\\Definition::((setFactoryService)|(setFactoryMethod))\(\)\.#'
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::((children)|(append))\(\)\.#'
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::((booleanNode)|(scalarNode))\(\)#'
-        - '#Parameter \#1 \$node of method OldSound\\RabbitMqBundle\\DependencyInjection\\Configuration::addQueueNodeConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition, Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition given\.#'
-        - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.#'
         - "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:ask\\(\\)\\.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,3 +19,5 @@ parameters:
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::((children)|(append))\(\)\.#'
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::((booleanNode)|(scalarNode))\(\)#'
         - "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:ask\\(\\)\\.$#"
+        - '#Parameter \#1 \$node of method OldSound\\RabbitMqBundle\\DependencyInjection\\Configuration::addQueueNodeConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition, Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition given\.#'
+        - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        backupGlobals               = "false"
-        backupStaticAttributes      = "false"
-        colors                      = "true"
-        convertErrorsToExceptions   = "true"
-        convertNoticesToExceptions  = "true"
-        convertWarningsToExceptions = "true"
-        processIsolation            = "false"
-        stopOnFailure               = "false"
-        bootstrap                   = "Tests/bootstrap.php">
-
+        colors="true"
+        stopOnFailure="false"
+        bootstrap="Tests/bootstrap.php"
+>
     <testsuites>
         <testsuite name="OldSoundRabbitMqBundle Test Suite">
             <directory>Tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory>.</directory>
-            <exclude>
-                <directory>Resources</directory>
-                <directory>Tests</directory>
-                <directory>vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>Resources</directory>
+            <directory>Tests</directory>
+            <directory>vendor</directory>
+        </exclude>
+    </source>
 
     <php>
         <server name="KERNEL_CLASS" value="\OldSound\RabbitMqBundle\Tests\TestKernel"/>


### PR DESCRIPTION
This pull request refactors the test suite to use the Pest testing framework instead of PHPUnit, resulting in more concise and modern test files. The main changes include removing the abstract `BaseCommandTest` class, converting test classes to Pest's function-based syntax, and moving setup logic into `beforeEach()` hooks. This improves test readability and maintainability.

Test suite modernization and migration to Pest:

* Removed the abstract `BaseCommandTest` class, as Pest handles shared setup via `beforeEach()` hooks instead of inheritance. (`Tests/Command/BaseCommandTest.php`)
* Converted command test classes (`ConsumerCommandTest`, `DynamicConsumerCommandTest`, `MultipleConsumerCommandTest`, `PurgeCommandTest`) from PHPUnit to Pest, replacing class-based tests and `setUp()` with `beforeEach()` and Pest's function-based `test()` syntax. (`Tests/Command/ConsumerCommandTest.php`, `Tests/Command/DynamicConsumerCommandTest.php`, `Tests/Command/MultipleConsumerCommandTest.php`, `Tests/Command/PurgeCommandTest.php`) [[1]](diffhunk://#diff-8de8a26e12a4e97db965b6f56bfb6b9ba6af37ce3fbedbeed3da8350daa29f5fL3-R45) [[2]](diffhunk://#diff-02e33ce3c5cfa382bdf89058d6d23b3e8436c2bafbf268690dea58f91c36cff1L3-R48) [[3]](diffhunk://#diff-8f1d76f87283ff1a8e2ecb3e152ed046e265b38529e171d45dba35cc78411d3aL3-R48) [[4]](diffhunk://#diff-7f4d5ef6408f2e3de9c0af0eb55a35a9c298316ef23f2bacc1aee632174157f3L3-R34)
* Updated event test files (`AfterProcessingMessageEventTest`, `BeforeProcessingMessageEventTest`, `OnIdleEventTest`) to Pest syntax, removing class wrappers and using `test()` functions for clarity and brevity. (`Tests/Event/AfterProcessingMessageEventTest.php`, `Tests/Event/BeforeProcessingMessageEventTest.php`, `Tests/Event/OnIdleEventTest.php`) [[1]](diffhunk://#diff-7bcd031f8c3961fe3461d1727de6750c51b840a539b8fb59070ddd33192d22e2L3-R22) [[2]](diffhunk://#diff-154375b65fe86eacb2fbccac9779d94baa6805c89e6de9fdaadeffa589a5b95eL3-R22) [[3]](diffhunk://#diff-362fa46a09049abc9d51c55c718b57651341aee7e610b73293dcc95e687789abL3-R36)